### PR TITLE
Use Unicode instead of Str in the tutorial examples

### DIFF
--- a/docs/source/instructional/tut_person.rst
+++ b/docs/source/instructional/tut_person.rst
@@ -154,9 +154,9 @@ the attribute names of the ``person`` object used by the ``PersonForm`` in the
     """ A simple class representing a person object.
 
     """
-    last_name = Str()
+    last_name = Unicode()
 
-    first_name = Str()
+    first_name = Unicode()
 
     age = Range(low=0)
 

--- a/examples/tutorial/employee/employee.py
+++ b/examples/tutorial/employee/employee.py
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 import datetime
 
-from atom.api import Atom, Str, Range, Bool, Value, Int, Tuple, observe
+from atom.api import Atom, Unicode, Range, Bool, Value, Int, Tuple, observe
 import enaml
 from enaml.qt.qt_application import QtApplication
 
@@ -16,9 +16,9 @@ class Person(Atom):
     """ A simple class representing a person object.
 
     """
-    last_name = Str()
+    last_name = Unicode()
 
-    first_name = Str()
+    first_name = Unicode()
 
     age = Range(low=0)
 
@@ -44,7 +44,7 @@ class Employer(Person):
 
     """
     # The name of the company
-    company_name = Str()
+    company_name = Unicode()
 
 
 class Employee(Person):
@@ -83,5 +83,3 @@ if __name__ == '__main__':
     view.show()
 
     app.start()
-
-

--- a/examples/tutorial/person/person.py
+++ b/examples/tutorial/person/person.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Atom, Str, Range, Bool, observe
+from atom.api import Atom, Unicode, Range, Bool, observe
 
 import enaml
 from enaml.qt.qt_application import QtApplication
@@ -15,9 +15,9 @@ class Person(Atom):
     """ A simple class representing a person object.
 
     """
-    last_name = Str()
+    last_name = Unicode()
 
-    first_name = Str()
+    first_name = Unicode()
 
     age = Range(low=0)
 


### PR DESCRIPTION
Without this change, the "person" and "employee" examples raise an exception when focus is lost in a modified text field:

```
$ python person.py 
Traceback (most recent call last):
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/qt/qt_field.py", line 125, in on_submit_text
    self._validate_and_apply()
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/qt/qt_field.py", line 95, in _validate_and_apply
    d.text = text
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/core/declarative_meta.py", line 67, in declarative_change_handler
    engine.write(owner, change['name'], change)
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/core/expression_engine.py", line 210, in write
    pair.writer(owner, name, change)
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/core/standard_handlers.py", line 120, in __call__
    call_func(func, (inverter, change['value']), {}, scope)
  File "/home/warren/gitwork/nucleic_enaml/examples/tutorial/person/person_view.enaml", line 17, in <module>
    text := person.first_name
  File "/home/warren/local_enaml/lib/python2.7/site-packages/enaml-0.8.0-py2.7-linux-x86_64.egg/enaml/core/standard_inverter.py", line 47, in load_attr
    setattr(obj, attr, value)
TypeError: The 'first_name' member on the 'Person' object must be of type 'str'. Got object of type 'unicode' instead.
```
