### PR TITLE
In the slider example, use a Form for the label and value, so the baselines of the text fields are aligned.

### DIFF
--- a/examples/widgets/slider.enaml
+++ b/examples/widgets/slider.enaml
@@ -12,18 +12,17 @@ used to compute the log of a range of numbers.
 
 """
 import math
-from enaml.widgets.api import Window, Container, Label, Field, Slider, Form
+from enaml.widgets.api import Window, Form, Label, Field, Slider
 
 
 enamldef Main(Window):
     title = 'Slider Example'
-    Container:
-        Form:
-            Label: lbl:
-                text = 'Log Value'
-            Field: fld:
-                text << u'{}'.format(math.log(slider.value))
-                read_only = True
+    Form:
+        Label: lbl:
+            text = 'Log Value'
+        Field: fld:
+            text << u'{}'.format(math.log(slider.value))
+            read_only = True
         Slider: slider:
             tick_interval = 50
             maximum = 1000


### PR DESCRIPTION
In Linux (Ubuntu 12.04), with either PyQt4 or PySide, the text in the label and the text in the numeric field were not properly aligned vertically.  By using a Form to contain them, the baselines are nicely aligned.
