### PR TITLE
add a mode to use the size hint from the current item

### DIFF
--- a/enaml/qt/qt_stack.py
+++ b/enaml/qt/qt_stack.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Int, Typed
+from atom.api import Int, IntEnum, Typed
 
 from enaml.widgets.stack import ProxyStack
 
@@ -63,6 +63,20 @@ class QStack(QStackedWidget):
     """ A QStackedWidget subclass which adds support for transitions.
 
     """
+    class SizeHintMode(IntEnum):
+        """ An int enum defining the size hint modes of the stack.
+
+        """
+        #: The size hint is the union of all stack items.
+        Union = 0
+
+        #: The size hint is the size hint of the current stack item.
+        Current = 1
+
+    #: Proxy the SizeHintMode values as if it were an anonymous enum.
+    Union = SizeHintMode.Union
+    Current = SizeHintMode.Current
+
     #: A signal emitted when a LayoutRequest event is posted to the
     #: stack widget. This will typically occur when the size hint of
     #: the stack is no longer valid.
@@ -82,6 +96,7 @@ class QStack(QStackedWidget):
         self._painter = None
         self._transition = None
         self._transition_index = 0
+        self._size_hint_mode = QStack.Union
 
     #--------------------------------------------------------------------------
     # Private API
@@ -168,6 +183,57 @@ class QStack(QStackedWidget):
             self.layoutRequested.emit()
         return res
 
+    def sizeHint(self):
+        """ A reimplemented size hint handler.
+
+        This method will compute the size hint based on the size hint
+        of the current tab, instead of the default behavior which is
+        the maximum of all the size hints of the tabs.
+
+        """
+        if self._size_hint_mode == QStack.Current:
+            curr = self.currentWidget()
+            if curr is not None:
+                return curr.sizeHint()
+        return super(QStack, self).sizeHint()
+
+    def minimumSizeHint(self):
+        """ A reimplemented minimum size hint handler.
+
+        This method will compute the size hint based on the size hint
+        of the current tab, instead of the default behavior which is
+        the maximum of all the minimum size hints of the tabs.
+
+        """
+        if self._size_hint_mode == QStack.Current:
+            curr = self.currentWidget()
+            if curr is not None:
+                return curr.minimumSizeHint()
+        return super(QStack, self).minimumSizeHint()
+
+    def sizeHintMode(self):
+        """ Get the size hint mode of the stack.
+
+        Returns
+        -------
+        result : QStack.SizeHintMode
+            The size hint mode enum value for the stack.
+
+        """
+        return self._size_hint_mode
+
+    def setSizeHintMode(self, mode):
+        """ Set the size hint mode of the stack.
+
+        Parameters
+        ----------
+        mode : QStack.SizeHintMode
+            The size hint mode for the stack.
+
+        """
+        assert isinstance(mode, QStack.SizeHintMode)
+        self._size_hint_mode = mode
+
     def transition(self):
         """ Get the transition installed on this widget.
 
@@ -219,6 +285,13 @@ class QStack(QStackedWidget):
             self.setCurrentIndex(index)
 
 
+#: A mapping Enaml -> Qt size hint modes.
+SIZE_HINT_MODE = {
+    'union': QStack.Union,
+    'current': QStack.Current,
+}
+
+
 #: Cyclic notification guard
 INDEX_FLAG = 0x1
 
@@ -247,7 +320,9 @@ class QtStack(QtConstraintsWidget, ProxyStack):
 
         """
         super(QtStack, self).init_widget()
-        self.set_transition(self.declaration.transition)
+        d = self.declaration
+        self.set_transition(d.transition)
+        self.set_size_hint_mode(d.size_hint_mode, update=False)
 
     def init_layout(self):
         """ Initialize the layout of the underlying control.
@@ -337,3 +412,11 @@ class QtStack(QtConstraintsWidget, ProxyStack):
             self.widget.setTransition(make_transition(transition))
         else:
             self.widget.setTransition(None)
+
+    def set_size_hint_mode(self, mode, update=True):
+        """ Set the size hint mode for the widget.
+
+        """
+        self.widget.setSizeHintMode(SIZE_HINT_MODE[mode])
+        if update:
+            self.size_hint_updated()

--- a/enaml/widgets/notebook.py
+++ b/enaml/widgets/notebook.py
@@ -37,6 +37,9 @@ class ProxyNotebook(ProxyConstraintsWidget):
     def set_selected_tab(self, name):
         raise NotImplementedError
 
+    def set_size_hint_mode(self, mode):
+        raise NotImplementedError
+
 
 class Notebook(ConstraintsWidget):
     """ A component which displays its children as tabbed pages.
@@ -60,6 +63,12 @@ class Notebook(ConstraintsWidget):
     #: The object name for the selected tab in the notebook.
     selected_tab = d_(Unicode())
 
+    #: The size hint mode for the stack. The default is 'union' and
+    #: means that the size hint of the notebook is the union of all
+    #: the tab size hints. 'current' means the size hint of the
+    #: notebook will be the size hint of the current tab.
+    size_hint_mode = d_(Enum('union', 'current'))
+
     #: A notebook expands freely in height and width by default.
     hug_width = set_default('ignore')
     hug_height = set_default('ignore')
@@ -77,7 +86,7 @@ class Notebook(ConstraintsWidget):
     # Observers
     #--------------------------------------------------------------------------
     @observe('tab_style', 'tab_position', 'tabs_closable', 'tabs_movable',
-        'selected_tab')
+        'selected_tab', 'size_hint_mode')
     def _update_proxy(self, change):
         """ Send the state change to the proxy.
 

--- a/enaml/widgets/stack.py
+++ b/enaml/widgets/stack.py
@@ -47,6 +47,9 @@ class ProxyStack(ProxyConstraintsWidget):
     def set_transition(self, transition):
         raise NotImplementedError
 
+    def set_size_hint_mode(self, mode):
+        raise NotImplementedError
+
 
 class Stack(ConstraintsWidget):
     """ A component which displays its children as a stack of widgets,
@@ -61,6 +64,12 @@ class Stack(ConstraintsWidget):
 
     #: The item transition to use when changing between stack items.
     transition = d_(Typed(Transition))
+
+    #: The size hint mode for the stack. The default is 'union' and
+    #: means that the size hint of the stack is the union of all the
+    #: stack item size hints. 'current' means the size hint of the
+    #: stack will be the size hint of the current stack item.
+    size_hint_mode = d_(Enum('union', 'current'))
 
     #: A Stack expands freely in height and width by default
     hug_width = set_default('ignore')
@@ -78,7 +87,7 @@ class Stack(ConstraintsWidget):
     #--------------------------------------------------------------------------
     # Observers
     #--------------------------------------------------------------------------
-    @observe('index', 'transition')
+    @observe('index', 'transition', 'size_hint_mode')
     def _update_proxy(self, change):
         """ An observer which sends state change to the proxy.
 

--- a/enaml/wx/wx_notebook.py
+++ b/enaml/wx/wx_notebook.py
@@ -503,3 +503,9 @@ class WxNotebook(WxConstraintsWidget, ProxyNotebook):
             else:
                flags &= ~aui.AUI_NB_TAB_MOVE
             widget.SetAGWWindowStyleFlag(flags)
+
+    def set_size_hint_mode(self, mode):
+        """ This is not supported on Wx.
+
+        """
+        pass


### PR DESCRIPTION
This gives `Notebook` and `Stack` a `size_hint_mode` attribute. The default mode 'union' represents the current behavior where the size hint of the notebook|stack is the union of the size hints of its children. The 'current' mode puts the widget into a mode where its size hint will be the currently selected tab|stackitem.

This addresses #72.
