### PR TITLE
BUG: Coerce new event code to QEvent.Type.

### DIFF
--- a/enaml/qt/q_deferred_caller.py
+++ b/enaml/qt/q_deferred_caller.py
@@ -15,7 +15,8 @@ class DeferredCallEvent(QEvent):
     """
     __slots__ = ('callback', 'args', 'kwargs')
 
-    Type = QEvent.registerEventType()
+    # Explicitly coerce to QEvent.Type for PySide compatibility.
+    Type = QEvent.Type(QEvent.registerEventType())
 
     def __init__(self, callback, args, kwargs):
         super(DeferredCallEvent, self).__init__(self.Type)


### PR DESCRIPTION
In PySide, QEvent strictly only accepts objects of type QEvent.Type. The
integer returned from QEvent.registerEventType() needs to be coerced.
