### PR TITLE
BUG: Remove __slots__ from QEvent subclass.

### DIFF
--- a/enaml/qt/q_deferred_caller.py
+++ b/enaml/qt/q_deferred_caller.py
@@ -13,8 +13,6 @@ class DeferredCallEvent(QEvent):
     """ A custom event type for deferred call events.
 
     """
-    __slots__ = ('callback', 'args', 'kwargs')
-
     # Explicitly coerce to QEvent.Type for PySide compatibility.
     Type = QEvent.Type(QEvent.registerEventType())
 


### PR DESCRIPTION
`QEvent` already has a `__dict__` in both PyQt4 and PySide, so adding `__slots__` will not save anything. Furthermore, adding `__slots__` to a `QEvent` subclass causes a segfault in PySide.
