### PR TITLE
fix the potential for unsafe code when running under pyqt

### DIFF
--- a/enaml/qt/qt_toolkit_object.py
+++ b/enaml/qt/qt_toolkit_object.py
@@ -9,7 +9,6 @@ from atom.api import Typed
 
 from enaml.widgets.toolkit_object import ProxyToolkitObject
 
-from . import QT_API
 from .QtCore import QObject
 
 
@@ -17,9 +16,9 @@ class QtToolkitObject(ProxyToolkitObject):
     """ A Qt implementation of an Enaml ProxyToolkitObject.
 
     """
-    # PySide requires weakrefs for using bound methods as slots
-    if QT_API == 'pyside':
-        __slots__ = '__weakref__'
+    # PySide requires weakrefs for using bound methods as slots.
+    # PyQt doesn't, but executes unsafe code if not using weakrefs.
+    __slots__ = '__weakref__'
 
     #: A reference to the toolkit widget created by the proxy.
     widget = Typed(QObject)


### PR DESCRIPTION
This demonstrates the danger of not have weakref'able object slots:

``` python
In [1]: from PyQt4.QtCore import *

In [2]: class Foo(object):
   ...:     __slots__ = ()
   ...:     def foo(self):
   ...:         print 'fired'
   ...:     def __del__(self):
   ...:         print 'collected'
   ...:

In [3]: class Bar(QObject):
   ...:     triggered = pyqtSignal()
   ...:

In [4]: f = Foo()

In [5]: b = Bar()

In [6]: b.triggered.connect(f.foo)

In [7]: b.triggered.emit()
fired

In [8]: del f
collected

In [9]: b.triggered.emit()
fired
```
