### PR TITLE
Make sure the Qt UI control is deleted when `destroy` is called.

### DIFF
--- a/enaml/qt/qt_toolkit_object.py
+++ b/enaml/qt/qt_toolkit_object.py
@@ -90,6 +90,7 @@ class QtToolkitObject(ProxyToolkitObject):
         """
         if self.widget is not None:
             self.widget.setParent(None)
+            self.widget.deleteLater()
             del self.widget
         super(QtToolkitObject, self).destroy()
 


### PR DESCRIPTION
If there is a reference to the UI control, deleting the `widget` instance attribute will not delete the Qt control itself.

This PR defines a failing test for this issue:
https://github.com/enthought/traits-enaml/pull/24
