### PR TITLE
Remove extraneous file after gh-pages build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,4 @@ gh-pages:
 	git push upstream-rw gh-pages
 	rm -rf ../enaml_docs
 	git checkout master
+	rm docs/.buildinfo


### PR DESCRIPTION
I knew there was a reason I nuked the docs folder.
