### PR TITLE
Work around some mro issues with Pyside and QDialog

### DIFF
--- a/enaml/qt/qt_dialog.py
+++ b/enaml/qt/qt_dialog.py
@@ -9,12 +9,13 @@ from atom.api import Typed
 
 from enaml.widgets.dialog import ProxyDialog
 
-from .QtCore import Qt, Signal
-from .QtGui import QDialog
+from .QtCore import Qt, Signal, QSize
+from .QtGui import QDialog, QLayout
 
-from .q_window_base import QWindowBase
+from .q_window_base import QWindowBase, QWindowLayout
 from .qt_window import QtWindow
 
+from . import QT_API 
 
 class QWindowDialog(QDialog, QWindowBase):
     """ A window base subclass which implements dialog behavior.
@@ -36,6 +37,14 @@ class QWindowDialog(QDialog, QWindowBase):
 
         """
         super(QWindowDialog, self).__init__(parent, flags)
+        #Pyside's mro goes off the rails and the QWindowBase.__init__ method does not get called.
+        #Copy in the necessary layout code here. 
+        if QT_API == 'pyside':
+            self._expl_min_size = QSize()
+            self._expl_max_size = QSize()
+            layout = QWindowLayout()
+            layout.setSizeConstraint(QLayout.SetMinAndMaxSize)
+            self.setLayout(layout)
 
 
 class QtDialog(QtWindow, ProxyDialog):


### PR DESCRIPTION
This "fixes" nucleic/enaml#108.  It seems a hack to me but the mro issues are beyond my abilities.  My understanding of the issue is
- QWindowDialog inherits from both QDialog and QWindowBase.  This gives a diamond inheritance pattern at QWidget but I'm not sure if that's the problem. 
- The layout setup happens in `QWindowBase.__init__`
- In `PyQt: QDialog.__init__` is a `<slot wrapper '__init__' of 'sip.simplewrapper' objects>` but `somehow the QWindowBase __init__` is called. 
- In `PySide: QDialog.__init__` is a `<slot wrapper '__init__' of 'PySide.QtGui.QDialog' objects>` and `QWindowBase.__init__` is not called. 

Trying in PySide to only call QWindowBase.**init** led to seg. faults. 
