### PR TITLE
Fixed examples/tutorials/phone_validator.py

### DIFF
--- a/examples/tutorial/employee/phone_validator.py
+++ b/examples/tutorial/employee/phone_validator.py
@@ -20,7 +20,7 @@ class PhoneNumberValidator(Validator):
 
     proper = re.compile(r'\(([0-9]{3})\)\ ([0-9]{3})\-([0-9]{4})$')
 
-    def validate(self, text, component):
+    def validate(self, text):
         match = self.proper.match(text) or self.dashes.match(text)
         if match:
             area = match.group(1)


### PR DESCRIPTION
Removed extra (and not used) parameter from validate() in "examples/tutorials/phone_validator.py" which was making the example print errors when a phone number was entered
