### PR TITLE
Fixing parser issues related to import

### DIFF
--- a/enaml/core/parser.py
+++ b/enaml/core/parser.py
@@ -2240,8 +2240,8 @@ def p_import_from4(p):
 
 
 def p_import_from5(p):
-    ''' import_from : FROM import_from_dots dotted_name IMPORT import_as_name '''
-    imprt = ast.ImportFrom(module=p[3], names=[p[5]], level=len(p[2]))
+    ''' import_from : FROM import_from_dots dotted_name IMPORT import_as_names '''
+    imprt = ast.ImportFrom(module=p[3], names=p[5], level=len(p[2]))
     imprt.col_offset = 0
     p[0] = imprt
 
@@ -2283,6 +2283,16 @@ def p_import_from_dots1(p):
 def p_import_from_dots2(p):
     ''' import_from_dots : import_from_dots DOT '''
     p[0] = p[1] + [p[2]]
+
+
+def p_imports_from_dots3(p):
+    ''' import_from_dots : ELLIPSIS'''
+    p[0] = [p[1], p[1], p[1]]
+
+
+def p_imports_from_dots4(p):
+    ''' import_from_dots : import_from_dots ELLIPSIS'''
+    p[0] = p[1] + [p[2], p[2], p[2]]
 
 
 def p_import_as_name1(p):


### PR DESCRIPTION
This fixes both #122 and #123.
#122 was linked to the fact that '...' is seen by the lexer as an Ellipsis token. To keep changes to a minimum two new import_from_dots rules have been added to deal with the fact that we can have DOT or ELLIPSIS (tested up to seven '.')
#123 was related to a 'double' typo error import_as_name was used in place of import_as_names but the ast.Module was built with [names] so that for a single name it worked.

NB : You may have to delete the parsetab.py because it is not always correctly updated when the parser in imported if the rules gave changed.
