### PR TITLE
Expose QTabWidget to styling for tabbed DockItem

### DIFF
--- a/enaml/qt/styleutil.py
+++ b/enaml/qt/styleutil.py
@@ -282,6 +282,10 @@ def _base_dock_item(name, pc):
     return _maybe_alert(u'QDockItem', name, pc)
 
 
+def _tabbed_dock_item(name, pc):
+    return _maybe_alert(u'QTabWidget QDockItem', name, pc)
+
+
 def _title_bar(name, pc):
     return _maybe_alert(u'QDockTitleBar', name, pc)
 
@@ -336,6 +340,7 @@ _DOCK_AREA_PSEUDO_ELEMENTS = {
 
 _DOCK_ITEM_PSEUDO_ELEMENTS = {
     u'': _base_dock_item,
+    u'tabbed': _tabbed_dock_item,
     u'title-bar': _title_bar,
     u'title-bar-label': _title_bar_label,
     u'title-bar-button': _title_bar_button,


### PR DESCRIPTION
I would like the ability to style the QTabWidget for docked items. 
