### PR TITLE
BUG: Employee's age was not being computed.

### DIFF
--- a/examples/tutorial/employee/employee.py
+++ b/examples/tutorial/employee/employee.py
@@ -38,6 +38,22 @@ class Person(Atom):
             )
             print s
 
+    @observe('dob')
+    def update_age(self, change):
+        """ Update the person's age whenever their date of birth changes
+
+        """
+        # grab the current date time
+        now = datetime.datetime.utcnow()
+        # estimate the person's age within one year accuracy
+        age = now.year - self.dob.year
+        # check to see if the current date is before their birthday and
+        # subtract a year from their age if it is
+        if now.month >= self.dob.month and now.day > self.dob.day:
+            age -= 1
+        # set the persons age
+        self.age = age
+
 
 class Employer(Person):
     """ An employer is a person who runs a company.


### PR DESCRIPTION
I noticed that the employee's age was not being computed in the Employee tutorial.  Here's a patch so that the age is actually computed when the `dob` changes.
