### PR TITLE
ENH: Implemented Autocorrect flag on numerical fields

### DIFF
--- a/enaml/stdlib/fields.enaml
+++ b/enaml/stdlib/fields.enaml
@@ -39,9 +39,13 @@ enamldef IntField(Field):
     attr base = 10
     attr value : int = 0
     attr converter << _int_converters.get(base, unicode)
+    attr fix_invalid_input : bool = False
     text << converter(value)
     text :: self.value = int(text, base)
-    validator << IntValidator(base=base, minimum=minimum, maximum=maximum)
+    validator << IntValidator(
+        base=base, minimum=minimum, maximum=maximum,
+        fix_invalid_input=fix_invalid_input
+    )
 
 
 enamldef FloatField(Field):
@@ -53,8 +57,10 @@ enamldef FloatField(Field):
     attr allow_exponent : bool = True
     attr value : float = 0.0
     attr converter = unicode
+    attr fix_invalid_input : bool = False
     text << converter(value)
     text :: self.value = float(text)
     validator << FloatValidator(
-        minimum=minimum, maximum=maximum, allow_exponent=allow_exponent
+        minimum=minimum, maximum=maximum, allow_exponent=allow_exponent,
+        fix_invalid_input=fix_invalid_input
     )

--- a/enaml/validator.py
+++ b/enaml/validator.py
@@ -77,6 +77,10 @@ class IntValidator(Validator):
     #: The base in which the int is represented.
     base = Enum(10, 2, 8, 16)
 
+    #: Whether or not to automatically fix user input if it is
+    #: outside of the bounds set by minimum and maximum
+    fix_invalid_input = Bool(False)
+
     def validate(self, text):
         """ Validates the given text matches the integer range.
 
@@ -103,6 +107,30 @@ class IntValidator(Validator):
             return False
         return True
 
+    def fixup(self, text):
+        """ Fix the user input if fix_input is True
+
+        Parameters
+        ----------
+        text : unicode
+            The unicode text edited by the client widget.
+
+        Returns
+        -------
+        result : int
+            The value to place into the client widget
+        """
+        if self.fix_invalid_input:
+            try:
+                value = int(text)
+                if self.minimum is not None and value < self.minimum:
+                    text = self.minimum
+                elif self.maximum is not None and value > self.maximum:
+                    text = self.maximum
+            except ValueError:
+                # text isn't an int, return the input text
+                text = self.minimum
+        return str(text)
 
 class FloatValidator(Validator):
     """ A concrete Validator which handles floating point input.
@@ -121,6 +149,10 @@ class FloatValidator(Validator):
 
     #: Whether or not to allow exponents like '1e6' in the input.
     allow_exponent = Bool(True)
+
+    #: Whether or not to automatically fix user input if it is
+    #: outside of the bounds set by minimum and maximum
+    fix_invalid_input = Bool(False)
 
     def validate(self, text):
         """ Validates the given text matches the float range.
@@ -149,6 +181,31 @@ class FloatValidator(Validator):
         if not self.allow_exponent and 'e' in text.lower():
             return False
         return True
+
+    def fixup(self, text):
+        """ Fix the user input if fix_input is True
+
+        Parameters
+        ----------
+        text : unicode
+            The unicode text edited by the client widget.
+
+        Returns
+        -------
+        result : float
+            The value to place into the client widget
+        """
+        if self.fix_invalid_input:
+            try:
+                value = float(text)
+                if self.minimum is not None and value < self.minimum:
+                    text = self.minimum
+                elif self.maximum is not None and value > self.maximum:
+                    text = self.maximum
+            except ValueError:
+                # text isn't a float, return the input text
+                text = self.minimum
+        return str(text)
 
 
 class RegexValidator(Validator):

--- a/examples/stdlib/numerical_fields.enaml
+++ b/examples/stdlib/numerical_fields.enaml
@@ -1,0 +1,105 @@
+
+""" An example of using Float and Int fields with auto-correcting limits
+
+This example shows how the Enaml FloatField and IntField widgets can
+auto-correct user input based on the provided min/max values.
+<< autodoc-me >>
+"""
+
+from atom.api import Atom, Float, Int, Bool, observe
+from enaml.stdlib.fields import FloatField, IntField
+from enaml.widgets.api import (
+    CheckBox, Container, Field, Form, GroupBox, Label, ObjectCombo, PushButton,
+    SpinBox, Window, MainWindow,
+)
+
+class FieldModel(Atom):
+    float_val = Float(5.)
+    float_min = Float(1.6)
+    float_max = Float(42.)
+    float_autocorrect = Bool(True)
+
+    int_val = Int(2)
+    int_min = Int(0)
+    int_max = Int(10)
+    int_autocorrect = Bool(False)
+    @observe('float_val', 'float_min', 'float_max', 'float_autocorrect',
+             'int_val', 'int_min', 'int_max', 'int_autocorrect')
+
+    def something_changed(self, update):
+        try:
+            name = update['name']
+            oldvalue = update['oldvalue']
+            value = update['value']
+            print('{} changed from {} to {}'.format(name, oldvalue, value))
+        except KeyError as ke:
+            # seems to be thrown at program startup, but not again
+            print('KeyError thrown: {}'.format(ke))
+
+        self.print_current_state()
+
+
+    def print_current_state(self):
+        output = "FloatField params..."
+        output += "\n\tCurrent Value: {}".format(self.float_val)
+        output += "\n\tCurrent Minimum: {}".format(self.float_min)
+        output += "\n\tCurrent Maximum: {}".format(self.float_max)
+        output += "\n\tCurrent Autocorrect state: {}".format(
+            self.float_autocorrect)
+
+        output = "\n\nIntField params..."
+        output += "\n\tCurrent Value: {}".format(self.int_val)
+        output += "\n\tCurrent Minimum: {}".format(self.int_min)
+        output += "\n\tCurrent Maximum: {}".format(self.int_max)
+        output += "\n\tCurrent Autocorrect state: {}".format(
+            self.int_autocorrect)
+
+enamldef Main(MainWindow):
+    title = "FloatField and IntField example"
+    attr model = FieldModel()
+    Container:
+        GroupBox:
+            title = "FloatField example"
+            Form:
+                Label:
+                    text = "float field"
+                FloatField:
+                    value := model.float_val
+                    minimum << model.float_min
+                    maximum << model.float_max
+                    fix_invalid_input << model.float_autocorrect
+                Label:
+                    text = 'float field minimum'
+                FloatField:
+                    value := model.float_min
+                Label:
+                    text = 'float field maximum'
+                FloatField:
+                    value := model.float_max
+                Label:
+                    text = 'autocorrect out of bounds input'
+                CheckBox:
+                    checked := model.float_autocorrect
+        GroupBox:
+            title = "IntField example"
+            Form:
+                Label:
+                    text = "int field"
+                IntField:
+                    value := model.int_val
+                    minimum << model.int_min
+                    maximum << model.int_max
+                    fix_invalid_input << model.int_autocorrect
+                Label:
+                    text = 'int field minimum'
+                IntField:
+                    value := model.int_min
+                Label:
+                    text = 'int field maximum'
+                IntField:
+                    value := model.int_max
+                Label:
+                    text = 'autocorrect out of bounds input'
+                CheckBox:
+                    checked := model.int_autocorrect
+


### PR DESCRIPTION
I'm not sure if this functionality exists in enaml already as I didn't see it anywhere.

IntValidator and FloatValidator have a 'fix_invalid_input' attribute that controls whether the user input is corrected based on the 'minimum' and 'maximum' of those fields.

The file /enaml/examples/stdlib/numerical_fields.enaml demonstrates this utility.

Another architectural option would be to subclass `IntField` to something like `ValidatedIntField` and have the validation done in the subclass with the same concept being done to `FloatField` and `ValidatedFloatField`.  

Any preferences?