### PR TITLE
Fixes for font handling

### DIFF
--- a/enaml/fonts.py
+++ b/enaml/fonts.py
@@ -183,7 +183,8 @@ class FontMember(Coerced):
 
     A font member can be set to a Font, a string, or None. A string
     font will be parsed into a Font object. If the parsing fails,
-    the font will be None.
+    the font will be None.  Font strings must be given in CSS grammar,
+    e.g. 'bold 12pt arial', which is order dependant.
 
     """
     __slots__ = ()

--- a/examples/layout/advanced/button_ring.enaml
+++ b/examples/layout/advanced/button_ring.enaml
@@ -99,4 +99,4 @@ enamldef Main(MainWindow):
                 h_center == cntr.h_center,
             ]
             text = 'Button Ring'
-            font = 'arial 12 bold'
+            font = 'bold 12pt arial'


### PR DESCRIPTION
Make font parsing more flexible to order.  These now both work: `arial 12pt bold`, `12pt arial bold`.

Also corrected example that uses unsupported bare integer font size.