### PR TITLE
Fix mpl deprecation warning and add ability to supply canvas/toolbar

### DIFF
--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -99,13 +99,13 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                 layout.addWidget(toolbar)
                 layout.addWidget(self.canvas)
                 self.canvas.setParent(widget)
-                # use focus policy from mpl FigureManager
+                # Use focus policy from MPL FigureManager
                 self.canvas.setFocusPolicy(Qt.StrongFocus)
                 self.canvas.setFocus()
                 self.canvas.setVisible(True)
             else:
                 canvas = self.canvas
-                # reset and clear the toolbar
+                # Reset and clear the toolbar
                 canvas.toolbar.home()
                 canvas.toolbar.update()
                 figure.canvas = canvas

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -88,6 +88,7 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
             if not self.canvas:
                 if isinstance(figure.canvas, FigureCanvasQTAgg):
                     self.canvas = figure.canvas
+                    # Avoid RuntimeError due to multiple calls to destroy
                     if hasattr(self.canvas, 'manager'):
                         self.canvas.manager.toolbar = None
                     toolbar = self.canvas.toolbar
@@ -98,11 +99,13 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                 layout.addWidget(toolbar)
                 layout.addWidget(self.canvas)
                 self.canvas.setParent(widget)
+                # use focus policy from mpl FigureManager
                 self.canvas.setFocusPolicy(Qt.StrongFocus)
                 self.canvas.setFocus()
                 self.canvas.setVisible(True)
             else:
                 canvas = self.canvas
+                # reset and clear the toolbar
                 canvas.toolbar.home()
                 canvas.toolbar.update()
                 figure.canvas = canvas

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -97,17 +97,12 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                     if hasattr(canvas, 'manager'):
                         canvas.manager.toolbar = None
                     toolbar = canvas.toolbar
-                    toolbar.setParent(widget)
                 else:
                     toolbar = NavigationToolbar2QT(canvas, widget)
 
                 layout.addWidget(toolbar)
                 layout.addWidget(canvas)
-                canvas.setParent(widget)
-                # Use focus policy from MPL FigureManager
-                canvas.setFocusPolicy(Qt.StrongFocus)
-                canvas.setFocus()
-                canvas.setVisible(True)
+                canvas.setFocusPolicy(Qt.ClickFocus)
                 self.canvas = canvas
 
             else:
@@ -119,5 +114,15 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                 canvas.figure = figure
                 canvas.draw_idle()
 
+            self.canvas.setVisible(True)
             toolbar = self.canvas.toolbar
             toolbar.setVisible(self.declaration.toolbar_visible)
+
+        elif self.canvas:
+            self.canvas.setVisible(False)
+            self.canvas.draw_idle()
+
+    def focus_target(self):
+        """ Return the canvas as the focus target.
+        """
+        return self.canvas

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -79,7 +79,7 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
         widget = self.widget
         layout = widget.layout()
 
-        # Create the new figure and toolbar widgets if suitable ones have
+        # Create the new canvas and toolbar widgets if suitable ones have
         # not been created.
         # The canvas is manually set to visible, or QVBoxLayout will
         # ignore it for size hinting.

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -88,26 +88,27 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
             if not self.canvas:
 
                 if isinstance(figure.canvas, FigureCanvasQTAgg):
-                    self.canvas = figure.canvas
+                    canvas = figure.canvas
                 else:
-                    self.canvas = FigureCanvasQTAgg(figure)
+                    canvas = FigureCanvasQTAgg(figure)
 
-                if self.canvas.toolbar:
+                if canvas.toolbar:
                     # Avoid RuntimeError due to multiple calls to destroy
-                    if hasattr(self.canvas, 'manager'):
-                        self.canvas.manager.toolbar = None
-                    toolbar = self.canvas.toolbar
+                    if hasattr(canvas, 'manager'):
+                        canvas.manager.toolbar = None
+                    toolbar = canvas.toolbar
                     toolbar.setParent(widget)
                 else:
-                    toolbar = NavigationToolbar2QT(self.canvas, widget)
+                    toolbar = NavigationToolbar2QT(canvas, widget)
 
                 layout.addWidget(toolbar)
-                layout.addWidget(self.canvas)
-                self.canvas.setParent(widget)
+                layout.addWidget(canvas)
+                canvas.setParent(widget)
                 # Use focus policy from MPL FigureManager
-                self.canvas.setFocusPolicy(Qt.StrongFocus)
-                self.canvas.setFocus()
-                self.canvas.setVisible(True)
+                canvas.setFocusPolicy(Qt.StrongFocus)
+                canvas.setFocus()
+                canvas.setVisible(True)
+                self.canvas = canvas
 
             else:
                 canvas = self.canvas

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -10,7 +10,7 @@ from atom.api import Typed
 from enaml.widgets.mpl_canvas import ProxyMPLCanvas
 
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT
 
 from .QtCore import Qt
 from .QtGui import QFrame, QVBoxLayout
@@ -89,11 +89,17 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
         # visible, or QVBoxLayout will ignore it for size hinting.
         figure = self.declaration.figure
         if figure:
-            canvas = FigureCanvasQTAgg(figure)
+            if isinstance(figure.canvas, FigureCanvasQTAgg):
+                canvas = figure.canvas
+                canvas.manager.toolbar = None
+                toolbar = canvas.toolbar
+                toolbar.setParent(widget)
+            else:
+                canvas = FigureCanvasQTAgg(figure)
+                toolbar = NavigationToolbar2QT(canvas, widget)
             canvas.setParent(widget)
             canvas.setFocusPolicy(Qt.ClickFocus)
             canvas.setVisible(True)
-            toolbar = NavigationToolbar2QTAgg(canvas, widget)
             toolbar.setVisible(self.declaration.toolbar_visible)
             layout.addWidget(toolbar)
             layout.addWidget(canvas)

--- a/enaml/qt/qt_mpl_canvas.py
+++ b/enaml/qt/qt_mpl_canvas.py
@@ -86,16 +86,21 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
         figure = self.declaration.figure
         if figure:
             if not self.canvas:
+
                 if isinstance(figure.canvas, FigureCanvasQTAgg):
                     self.canvas = figure.canvas
+                else:
+                    self.canvas = FigureCanvasQTAgg(figure)
+
+                if self.canvas.toolbar:
                     # Avoid RuntimeError due to multiple calls to destroy
                     if hasattr(self.canvas, 'manager'):
                         self.canvas.manager.toolbar = None
                     toolbar = self.canvas.toolbar
                     toolbar.setParent(widget)
                 else:
-                    self.canvas = FigureCanvasQTAgg(figure)
                     toolbar = NavigationToolbar2QT(self.canvas, widget)
+
                 layout.addWidget(toolbar)
                 layout.addWidget(self.canvas)
                 self.canvas.setParent(widget)
@@ -103,6 +108,7 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                 self.canvas.setFocusPolicy(Qt.StrongFocus)
                 self.canvas.setFocus()
                 self.canvas.setVisible(True)
+
             else:
                 canvas = self.canvas
                 # Reset and clear the toolbar
@@ -111,5 +117,6 @@ class QtMPLCanvas(QtControl, ProxyMPLCanvas):
                 figure.canvas = canvas
                 canvas.figure = figure
                 canvas.draw_idle()
+
             toolbar = self.canvas.toolbar
             toolbar.setVisible(self.declaration.toolbar_visible)

--- a/examples/widgets/mpl_canvas.enaml
+++ b/examples/widgets/mpl_canvas.enaml
@@ -29,6 +29,10 @@ figures = {
 }
 
 
+def keypress(event):
+    print(event.key)
+
+
 enamldef Main(Window):
     Container:
         constraints = [
@@ -46,3 +50,5 @@ enamldef Main(Window):
             checked := canvas.toolbar_visible
         MPLCanvas: canvas:
             figure << figures[cbox.selected_item]
+            activated ::
+                figure.canvas.mpl_connect('key_press_event', keypress)


### PR DESCRIPTION
The `NavigationToolbar2QTAgg` has been deprecated.
Also, I have an application that uses a custom Canvas and Toolbar, and this allows me to use them.
The `canvas.manager.toolbar = None` prevents the `FigureManager` from trying to destroy the toolbar, which resulted in a `RuntimeError`.
