### PR TITLE
Fix uninitialized `editable` attribute

### DIFF
--- a/enaml/qt/qt_object_combo.py
+++ b/enaml/qt/qt_object_combo.py
@@ -93,6 +93,7 @@ class QtObjectCombo(QtControl, ProxyObjectCombo):
         """
         super(QtObjectCombo, self).init_widget()
         self.refresh_items()
+        self.set_editable(self.declaration.editable)
         self.widget.currentIndexChanged.connect(self.on_index_changed)
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a bug where `editable` was not properly initialized by the backend ObjectCombo implementation.