### PR TITLE
Removed legacy dependency on distribute.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     description='Declarative DSL for building rich user interfaces in Python',
     long_description=open('README.rst').read(),
     requires=['atom', 'PyQt', 'ply', 'kiwisolver'],
-    install_requires=['distribute', 'atom >= 0.3.8', 'kiwisolver >= 0.1.2', 'ply >= 3.4'],
+    install_requires=['setuptools', 'atom >= 0.3.8', 'kiwisolver >= 0.1.2', 'ply >= 3.4'],
     packages=find_packages(),
     package_data={
         'enaml.applib': ['*.enaml'],


### PR DESCRIPTION
distribute is a legacy package.

Should the installation dependency be updated to require setuptools instead?
