### PR TITLE
Python 3 : C layer migration

### DIFF
--- a/enaml/src/declfunction.cpp
+++ b/enaml/src/declfunction.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <sstream>
 #include "pythonhelpersex.h"
+#include "py23compat.h"
 
 
 using namespace PythonHelpers;
@@ -145,8 +146,7 @@ DFunc_getset[] = {
 
 
 PyTypeObject DFunc_Type = {
-    PyObject_HEAD_INIT( &PyType_Type )
-    0,                                      /* ob_size */
+    PyVarObject_HEAD_INIT( &PyType_Type, 0 )
     "funchelper.DeclarativeFunction",       /* tp_name */
     sizeof( DFunc ),                        /* tp_basicsize */
     0,                                      /* tp_itemsize */
@@ -154,7 +154,13 @@ PyTypeObject DFunc_Type = {
     (printfunc)0,                           /* tp_print */
     (getattrfunc)0,                         /* tp_getattr */
     (setattrfunc)0,                         /* tp_setattr */
-    (cmpfunc)0,                             /* tp_compare */
+#if PY_VERSION_HEX >= 0x03050000
+	( PyAsyncMethods* )0,                   /* tp_as_async */
+#elif PY_VERSION_HEX >= 0x03000000
+	( void* ) 0,                            /* tp_reserved */
+#else
+	( cmpfunc )0,                           /* tp_compare */
+#endif
     (reprfunc)DFunc_repr,                   /* tp_repr */
     (PyNumberMethods*)0,                    /* tp_as_number */
     (PySequenceMethods*)0,                  /* tp_as_sequence */

--- a/enaml/src/py23compat.h
+++ b/enaml/src/py23compat.h
@@ -1,0 +1,56 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+#pragma once
+
+#include <Python.h>
+
+#if PY_MAJOR_VERSION >= 3
+
+#define Py23Str_Check PyUnicode_Check
+#define Py23Str_CheckExact PyUnicode_CheckExact
+#define Py23Str_AS_STRING PyUnicode_AsUTF8
+#define Py23Str_FromString PyUnicode_FromString
+#define Py23Str_InternFromString PyUnicode_InternFromString
+#define Py23Str_InternInPlace PyUnicode_InternInPlace
+#define Py23Str_FromFormat PyUnicode_FromFormat
+#define Py23Bytes_Check PyBytes_Check
+#define Py23Bytes_AS_STRING PyBytes_AS_STRING
+#define Py23Bytes_FromStringAndSize PyBytes_FromStringAndSize
+#define Py23Int_Check PyLong_Check
+#define Py23Int_FromLong PyLong_FromLong
+#define Py23Int_AsLong PyLong_AsLong
+#define Py23Number_Int PyNumber_Long
+#define Py23Int_AsSsize_t PyLong_AsSsize_t
+#define Py23Int_FromSsize_t PyLong_FromSsize_t
+
+#define INITERROR return NULL
+#define MOD_INIT_FUNC(name) PyMODINIT_FUNC PyInit_##name(void)
+
+#else
+
+#define Py23Str_Check PyString_Check
+#define Py23Str_CheckExact PyString_CheckExact
+#define Py23Str_AS_STRING PyString_AS_STRING
+#define Py23Str_FromString PyString_FromString
+#define Py23Str_InternFromString PyString_InternFromString
+#define Py23Str_InternInPlace PyString_InternInPlace
+#define Py23Str_FromFormat PyString_FromFormat
+#define Py23Bytes_Check PyString_Check
+#define Py23Bytes_AS_STRING PyString_AS_STRING
+#define Py23Bytes_FromStringAndSize PyString_FromStringAndSize
+#define Py23Int_Check( ob ) ( PyInt_Check( ob ) || PyLong_Check( ob ) )
+#define Py23Int_FromLong PyInt_FromLong
+#define Py23Int_AsLong PyInt_AsLong
+#define Py23Number_Int PyNumber_Int
+#define Py23Int_AsSsize_t PyInt_AsSsize_t
+#define Py23Int_FromSsize_t PyInt_FromSsize_t
+
+#define INITERROR return
+#define MOD_INIT_FUNC(name) PyMODINIT_FUNC init##name(void)
+
+#endif

--- a/enaml/src/pythonhelpers.h
+++ b/enaml/src/pythonhelpers.h
@@ -160,12 +160,12 @@ public:
 
     bool has_attr( PyObjectPtr& attr )
     {
-        return PyObject_HasAttr( m_pyobj, attr.get() );
+        return PyObject_HasAttr( m_pyobj, attr.get() ) != 0;
     }
 
     bool has_attr( const char* attr )
     {
-        return PyObject_HasAttrString( m_pyobj, attr );
+        return PyObject_HasAttrString( m_pyobj, attr ) != 0;
     }
 
     bool has_attr( std::string& attr )
@@ -453,7 +453,7 @@ public:
 
     PyObjectPtr get_class() const
     {
-        return PyObjectPtr( PyMethod_GET_CLASS( m_pyobj ), true );
+        return PyObjectPtr( (PyObject *)Py_TYPE( PyMethod_GET_SELF( m_pyobj ) ) );
     }
 
 };

--- a/enaml/src/pythonhelpersex.h
+++ b/enaml/src/pythonhelpersex.h
@@ -719,7 +719,7 @@ public:
 
     PyObjectPtr get_class() const
     {
-        return PyObjectPtr( PythonHelpers::xnewref( PyMethod_GET_CLASS( m_pyobj ) ) );
+        return PyObjectPtr( PythonHelpers::xnewref( (PyObject *)Py_TYPE( PyMethod_GET_SELF( m_pyobj ) ) ) );
     }
 
 };


### PR DESCRIPTION
This PR aims at making the C layer of enaml work on both Python 2 and 3. It is similar in shape to https://github.com/nucleic/atom/pull/65.

I suspect that something may be slightly wrong as I have seen in Python 3 cases in which a failed setattr (due to an exception in some handlers) was not reporting any exception (SystemError) while its Python 2 counterpart was. However I was not able to make a minimal example yet (so far they all work)

I largely edited the history to make it easier to review so I would like to thank @peterazmanov for its contribution (as it disappeared from the history)
