### PR TITLE
Fixed a typo in Looper example.

### DIFF
--- a/examples/dynamic/looper.enaml
+++ b/examples/dynamic/looper.enaml
@@ -33,7 +33,7 @@ enamldef Main(Window):
         PushButton: button:
             text = 'Print Items'
             clicked ::
-                for item in looper.items:
+                for item in looper.iterable:
                     print item
         ScrollArea: scroller:
             Container:


### PR DESCRIPTION
The example printed the __repr__ of the (internal) fields of the Looper object. Instead now it prints the strings inserted in the GUI in the 'Items' field, as it was intended to do.