### PR TITLE
travis: test the version of qt5 available on conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   include:
     - env: PYTHON=2.7 QT_VERSION=4 IPY_VERSION=3
     - env: PYTHON=3.4 QT_VERSION=4 IPY_VERSION=3
-    - env: PYTHON=3.5 QT_VERSION=5 IPY_VERSION=5
-    - env: PYTHON=3.6 QT_VERSION=5 IPY_VERSION=6
+    - env: PYTHON=3.5 QT_VERSION=5 IPY_VERSION=5 QSCINTILLA=0
+    - env: PYTHON=3.6 QT_VERSION=5 IPY_VERSION=6 QSCINTILLA=1
 
 before_install:
 
@@ -34,6 +34,7 @@ before_install:
   # Install enaml dependencies and include special widgets dependencies
   # We do not test vtk as it segfaults on Travis
   - $CONDA_INSTALL pyqt=$QT_VERSION ply matplotlib
+
   # Install qtpy from pip to get a recent version (>= 1.3) on python 3.4
   - $PIP_INSTALL qtpy
   - 'if [ $IPY_VERSION < 4 ]; then
@@ -42,10 +43,14 @@ before_install:
         $CONDA_INSTALL ipython=$IPY_VERSION qtconsole;
      fi'
 
-  # Install QScintilla (for Qt5)
-  - 'if [ $QT_VERSION -gt 4 ]; then
+  # Install QScintilla for Qt5 if requested
+  # This will force qt to the last available version on PyPI and means that
+  # we will have two versions of qt at the same time but it seems to work fine
+  - 'if [ $QT_VERSION -gt 4 ] && [ $QSCINTILLA -eq 1 ]; then
          $PIP_INSTALL QScintilla;
      fi'
+
+  # Install the dev version of the other nucleic projects
   - $PIP_INSTALL https://github.com/nucleic/atom/tarball/master
   - $PIP_INSTALL https://github.com/nucleic/kiwi/tarball/master
 
@@ -70,7 +75,6 @@ before_script:
 script:
   # Run the enaml test suite
   - cd $TRAVIS_BUILD_DIR
-#  - export QT_API=pyqt$QT_VERSION
   - py.test tests --cov enaml --cov-report xml -v
 
 after_success:


### PR DESCRIPTION
This was not the case anymore because QScintilla pulls pyqt 5.9  from PyPI.