### PR TITLE
Trace nested code objects

### DIFF
--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -13,6 +13,7 @@ from .byteplay import (
 )
 
 
+from . import byteplay as bp
 if not IS_PY3:
     from .byteplay import DUP_TOPX
 else:
@@ -243,7 +244,7 @@ class CodeInverter(object):
         self.fail()
 
 
-def inject_tracing(codelist):
+def inject_tracing(codelist, nested=False):
     """ Inject tracing code into the given code list.
 
     This will inject the bytecode operations required to trace the
@@ -255,6 +256,9 @@ def inject_tracing(codelist):
     ----------
     codelist : list
         The list of byteplay code ops to modify.
+    nested : bool
+        Is the code modified defined inside an already traced code in which
+        case the tracer is in the local namespace and not the fast locals.
 
     Returns
     -------
@@ -262,6 +266,10 @@ def inject_tracing(codelist):
         A *new* list of code ops which implement the desired behavior.
 
     """
+    # If the code is nested into another already traced code, we need to use
+    # LOAD_NAME to access it rather than LOAD_FAST
+    tracer_op = LOAD_NAME if nested else LOAD_FAST
+
     # This builds a mapping of code idx to a list of ops, which are the
     # tracing bytecode instructions which will be inserted into the code
     # object being transformed. The ops assume that a tracer object is
@@ -274,7 +282,7 @@ def inject_tracing(codelist):
         if op == LOAD_ATTR:
             code = [                        # obj
                 (DUP_TOP, None),            # obj -> obj
-                (LOAD_FAST, '_[tracer]'),   # obj -> obj -> tracer
+                (tracer_op, '_[tracer]'),   # obj -> obj -> tracer
                 (LOAD_ATTR, 'load_attr'),   # obj -> obj -> tracefunc
                 (ROT_TWO, None),            # obj -> tracefunc -> obj
                 (LOAD_CONST, op_arg),       # obj -> tracefunc -> obj -> attr
@@ -300,7 +308,7 @@ def inject_tracing(codelist):
             code = [                                               # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
                 (BUILD_TUPLE, n_stack_args),                       # func -> argtuple
                 (DUP_TOP_TWO, None) if IS_PY3 else (DUP_TOPX, 2),  # func -> argtuple -> func -> argtuple
-                (LOAD_FAST, '_[tracer]'),                          # func -> argtuple -> func -> argtuple -> tracer
+                (tracer_op, '_[tracer]'),                          # func -> argtuple -> func -> argtuple -> tracer
                 (LOAD_ATTR, 'call_function'),                      # func -> argtuple -> func -> argtuple -> tracefunc
                 (ROT_THREE, None),                                 # func -> argtuple -> tracefunc -> func -> argtuple
                 (LOAD_CONST, op_arg),                              # func -> argtuple -> tracefunc -> func -> argtuple -> argspec
@@ -325,7 +333,7 @@ def inject_tracing(codelist):
         elif op == BINARY_SUBSCR:
             code = [                                               # obj -> idx
                 (DUP_TOP_TWO, None) if IS_PY3 else (DUP_TOPX, 2),  # obj -> idx -> obj -> idx
-                (LOAD_FAST, '_[tracer]'),                          # obj -> idx -> obj -> idx -> tracer
+                (tracer_op, '_[tracer]'),                          # obj -> idx -> obj -> idx -> tracer
                 (LOAD_ATTR, 'binary_subscr'),                      # obj -> idx -> obj -> idx -> tracefunc
                 (ROT_THREE, None),                                 # obj -> idx -> tracefunc -> obj -> idx
                 (CALL_FUNCTION, 0x0002),                           # obj -> idx -> retval
@@ -335,7 +343,7 @@ def inject_tracing(codelist):
         elif op == GET_ITER:
             code = [                        # obj
                 (DUP_TOP, None),            # obj -> obj
-                (LOAD_FAST, '_[tracer]'),   # obj -> obj -> tracer
+                (tracer_op, '_[tracer]'),   # obj -> obj -> tracer
                 (LOAD_ATTR, 'get_iter'),    # obj -> obj -> tracefunc
                 (ROT_TWO, None),            # obj -> tracefunc -> obj
                 (CALL_FUNCTION, 0x0001),    # obj -> retval
@@ -345,13 +353,31 @@ def inject_tracing(codelist):
         elif op == RETURN_VALUE:
             code = [
                 (DUP_TOP, None),                # obj
-                (LOAD_FAST, '_[tracer]'),       # obj -> obj -> tracer
+                (tracer_op, '_[tracer]'),       # obj -> obj -> tracer
                 (LOAD_ATTR, 'return_value'),    # obj -> obj -> tracefunc
                 (ROT_TWO, None),                # obj -> tracefunc -> obj
                 (CALL_FUNCTION, 0x0001),        # obj -> retval
                 (POP_TOP, None),                # obj
             ]
             inserts[idx] = code
+        elif isinstance(op_arg, bp.Code):
+            # Inject tracing in nested code object.
+            # This handles the case of list/dict/set comprehensions that
+            # defines a nested function.
+
+            # As we cannot pass the tracer as argument to the function, get it
+            # from the dynamicscope that will find it in the fast locals and
+            # cache it. This will allow to access to it later
+            if not nested:
+                code = [
+                    (LOAD_NAME, 'locals'),      # localsfunc
+                    (CALL_FUNCTION, 0x0000),    # locals
+                    (LOAD_CONST, '_[tracer]'),  # locals -> '_[tracer]'
+                    (BINARY_SUBSCR, None),      # tracer
+                    (POP_TOP, None)             #
+                ]
+                inserts[idx] = code
+            op_arg.code = inject_tracing(op_arg.code, nested=True)
 
     # Create a new code list which interleaves the generated code with
     # the original code at the appropriate location.

--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -364,19 +364,6 @@ def inject_tracing(codelist, nested=False):
             # Inject tracing in nested code object.
             # This handles the case of list/dict/set comprehensions that
             # defines a nested function.
-
-            # As we cannot pass the tracer as argument to the function, get it
-            # from the dynamicscope that will find it in the fast locals and
-            # cache it. This will allow to access to it later
-            if not nested:
-                code = [
-                    (LOAD_NAME, 'locals'),      # localsfunc
-                    (CALL_FUNCTION, 0x0000),    # locals
-                    (LOAD_CONST, '_[tracer]'),  # locals -> '_[tracer]'
-                    (BINARY_SUBSCR, None),      # tracer
-                    (POP_TOP, None)             #
-                ]
-                inserts[idx] = code
             op_arg.code = inject_tracing(op_arg.code, nested=True)
 
     # Create a new code list which interleaves the generated code with

--- a/enaml/src/dynamicscope.cpp
+++ b/enaml/src/dynamicscope.cpp
@@ -634,6 +634,10 @@ DynamicScope_getitem( DynamicScope* self, PyObject* key )
     if( strcmp( (char *)Py23Str_AS_STRING( key ), "__scope__" ) == 0 )
         return newref( pyobject_cast( self ) );
 
+    // _[tracer] magic
+    if( strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
+        return newref( pyobject_cast( self->tracer ) );
+
     // value from the local scope
     res = PyObject_GetItem( self->f_locals, key );
     if( res )
@@ -718,6 +722,10 @@ DynamicScope_contains( DynamicScope* self, PyObject* key )
 
     // __scope__ magic
     if( strcmp( (char *)Py23Str_AS_STRING( key ), "__scope__" ) == 0 )
+        return 1;
+
+    // _[tracer] magic
+    if( strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
         return 1;
 
     // value from the local scope

--- a/enaml/src/dynamicscope.cpp
+++ b/enaml/src/dynamicscope.cpp
@@ -635,7 +635,7 @@ DynamicScope_getitem( DynamicScope* self, PyObject* key )
         return newref( pyobject_cast( self ) );
 
     // _[tracer] magic
-    if( strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
+    if( self->tracer && strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
         return newref( pyobject_cast( self->tracer ) );
 
     // value from the local scope
@@ -725,7 +725,7 @@ DynamicScope_contains( DynamicScope* self, PyObject* key )
         return 1;
 
     // _[tracer] magic
-    if( strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
+    if( self->tracer && strcmp( (char *)Py23Str_AS_STRING( key ), "_[tracer]" ) == 0 )
         return 1;
 
     // value from the local scope

--- a/tests/test_comprehensions.py
+++ b/tests/test_comprehensions.py
@@ -43,7 +43,7 @@ enamldef Main(Window):
         Field: search:
             placeholder = "Search..."
         Label: lab:
-            text << '{{0}}'.format({1})
+            text << '{{}}'.format({})
 
 """
 
@@ -80,7 +80,7 @@ def test_list_comprehension_synchronization():
     """Test running a list comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format('',
+    source = SYNCHRONISATION_TEMPLATE.format(
         '[c for c in colors if not search.text or search.text in c]')
     win = compile_source(source, 'Main')()
     assert win.formatted_comp == "['red', 'blue', 'yellow', 'green']"
@@ -114,7 +114,7 @@ def test_dict_comprehension_synchronisation():
     """Test running a dict comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format('',
+    source = SYNCHRONISATION_TEMPLATE.format(
         '{i: search.text for i in range(3)}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {0: '', 1: '', 2: ''}
@@ -145,7 +145,7 @@ def test_set_comprehension_synchronization():
     """Test running a set comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format('',
+    source = SYNCHRONISATION_TEMPLATE.format(
         '{search.text for i in range(3)}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {''}
@@ -175,7 +175,7 @@ def test_handling_nested_comprehension_synchronization():
     """Test handling nested comprehensions in a traced read.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format('',
+    source = SYNCHRONISATION_TEMPLATE.format(
         '{search.text for i in {j for j in colors}}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {''}


### PR DESCRIPTION
This allow to properly trace list/dict/set comprehensions which use a function. As a consequence the tracer has to be accessible from the function in the comprehension. 

Rather than modifying the function to of the comprehension to accept the tracer as argument, I chose to adapt the loading opcode based on whether or not we are dealing with a nested code object. To work, this requires the tracer to appear in the local namespace which requires a tiny trick to make it appear in the locals of the dynamicscope. This will have a penalty cost in term of speed for the traced comprehension but I believe this is acceptable.

The alternative would be to modify the function involved in the comprehension when the comprehension is involved in tracing, by changing its argument and modifying how it is called. It is feasible, but I am not sure it would be better than the solution I propose and I believe it would be more complex.

I will work on adding tests next.