### PR TITLE
Fix issue #206 (layout_container member not cleared when unparenting)

### DIFF
--- a/enaml/qt/qt_container.py
+++ b/enaml/qt/qt_container.py
@@ -350,6 +350,16 @@ class QtContainer(QtFrame, ProxyContainer):
         if cw is not None and cw.parent() != self.widget:
             cw.setParent(self.widget)
 
+    def child_removed(self, child):
+        """ Handle the child removed event.
+
+        This handler will clear the layout_parent member is applicable.
+
+        """
+        super(QtContainer, self).child_removed(child)
+        if isinstance(child, QtConstraintsWidget):
+            del child.layout_container
+
     #--------------------------------------------------------------------------
     # Layout API
     #--------------------------------------------------------------------------

--- a/tests/test_layout_container.py
+++ b/tests/test_layout_container.py
@@ -1,0 +1,72 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2013-2017, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+from utils import compile_source, wait_for_window_displayed
+
+
+MANUAL_REPARENTING = \
+"""from enaml.core.api import Conditional
+from enaml.widgets.api import (Window, Container, ObjectCombo, PushButton,
+                               ScrollArea, GroupBox, Label)
+
+
+enamldef Displayable(GroupBox): cont:
+
+    attr sp_children = []
+    alias btn_clicked : btn.clicked
+
+    func refresh():
+        for c in sp_children:
+            c.set_parent(self)
+            c.show()
+
+    initialized ::
+        refresh()
+
+    PushButton: btn:
+        text = 'Add label'
+        clicked ::
+            Label(text='Dummy').set_parent(cont)
+
+C2 = Displayable(title='C2')
+
+C1 = Displayable(title='C1', sp_children=[C2])
+
+
+enamldef Main(Window):
+
+    attr displayables = {'C1': C1, 'C2': C2}
+    alias selected_disp : cb.selected
+
+    initialized::
+        C1.set_parent(scroll)
+        C1.show()
+
+    Container:
+        ObjectCombo: cb:
+            items = sorted(displayables)
+            selected ::
+                view = displayables[change['value']]
+                view.set_parent(scroll)
+                view.refresh()
+                view.show()
+
+        ScrollArea: scroll:
+            pass
+"""
+
+
+def test_manual_reparenting(enaml_qtbot):
+    """Test manually reparenting widgets which are previously child and parent.
+
+    """
+    win = compile_source(MANUAL_REPARENTING, 'Main')()
+    win.show()
+    win.send_to_front()
+    wait_for_window_displayed(enaml_qtbot, win)
+    win.selected_disp = 'C2'
+    win.displayables['C2'].btn_clicked = True


### PR DESCRIPTION
Previously when a widget was unparented from a QtContainer subclass the layout_container member was not cleared. This could lead to bugs when a relayout of the widget was requested as it would try to relayout its old parent.
If the new one is not a Container the member is not updated. Furthermore, the old  parent layout can be out of sync if it is not displayed at the time, which is turns can lead to an index error as a child appears missing.

I believe this fix is the cheapest one as it does not attempt to change the layout of the parent.

The test expose the bug before the fix and pass afterwards.