### PR TITLE
Fixes for closure in comprehensions and tracing of lambda functions

### DIFF
--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -363,8 +363,6 @@ def inject_tracing(codelist, nested=False):
         elif isinstance(op_arg, bp.Code):
             # Inject tracing in nested code object if they use their parent
             # locals.
-            # This handles the case of list/dict/set comprehensions that
-            # defines a nested function.
             if not op_arg.newlocals:
                 op_arg.code = inject_tracing(op_arg.code, nested=True)
 

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -684,6 +684,7 @@ def gen_operator_binding(cg, node, index, name):
         code = compile(node.value.ast, cg.filename, mode=mode)
         for op, op_arg in bp.Code.from_code(code).code:
             if isinstance(op_arg, bp.Code):
+                rewrite_globals_access(op_arg, global_vars)
                 code = op_arg.to_code()
                 break
     else:

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -684,7 +684,6 @@ def gen_operator_binding(cg, node, index, name):
         code = compile(node.value.ast, cg.filename, mode=mode)
         for op, op_arg in bp.Code.from_code(code).code:
             if isinstance(op_arg, bp.Code):
-                rewrite_globals_access(op_arg, global_vars)
                 code = op_arg.to_code()
                 break
     else:

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -690,10 +690,12 @@ def gen_operator_binding(cg, node, index, name):
     else:
         code = compile(node.value.ast, cg.filename, mode=mode)
 
+    b_code = bp.Code.from_code(code)
     if has_defs:
-        b_code = bp.Code.from_code(code)
         run_in_dynamic_scope(b_code, global_vars)
-        code = b_code.to_code()
+    else:
+        rewrite_globals_access(b_code, global_vars)
+    code = b_code.to_code()
 
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -5,10 +5,13 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+from functools import update_wrapper
+
 from atom.api import Event, Instance, Member
 from atom.datastructures.api import sortedmap
 
 from .alias import Alias
+from .dynamicscope import DynamicScope
 from .compiler_nodes import (
     DeclarativeNode, EnamlDefNode, TemplateNode, TemplateInstanceNode
 )
@@ -736,6 +739,26 @@ def add_decl_function(node, func, is_override):
     setattr(klass, name, d_func)
 
 
+def wrap_function(func, scope):
+    """Wrap a function to call it with the dynamicscope in which it was defined
+
+    Parameters
+    ----------
+    func : FunctionType
+        Function for which a new scope need to be built
+
+    scope : DynamicScope
+        Scope in which the function was defined.
+
+    """
+    def wrapper(*args, **kwargs):
+        return call_func(func, args, kwargs, scope)
+
+    update_wrapper(wrapper, func)
+
+    return wrapper
+
+
 __compiler_helpers = {
     'add_alias': add_alias,
     'add_decl_function': add_decl_function,
@@ -755,5 +778,5 @@ __compiler_helpers = {
     'validate_spec': validate_spec,
     'validate_template': validate_template,
     'validate_unpack_size': validate_unpack_size,
-    'call_func': call_func,
+    'wrap_func': wrap_function,
 }

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -11,7 +11,6 @@ from atom.api import Event, Instance, Member
 from atom.datastructures.api import sortedmap
 
 from .alias import Alias
-from .dynamicscope import DynamicScope
 from .compiler_nodes import (
     DeclarativeNode, EnamlDefNode, TemplateNode, TemplateInstanceNode
 )

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -132,7 +132,11 @@ from .template_compiler import TemplateCompiler
 # 23 : Support for Python 3 and inlining of comprehensions.
 # 24 : Call comprehension functions in the proper scope rather than inlining
 # 25 : Support for Python 3.6
-COMPILER_VERSION = 25
+# 26 : Wrap functions defined inside operators or declarative function to call
+#      them with their scope of definition. This allows to handle properly
+#      comprehensions and lambdas. Also ensure that we compile the body of the
+#      :: operator as a function to properly handle closure.
+COMPILER_VERSION = 26
 
 
 # Code that will be executed at the top of every enaml module


### PR DESCRIPTION
Wrap functions defined inside operators or declarative function to call them with their scope of definition. This allows to handle properly comprehensions and lambdas (whose body is now properly traced). Also ensure that we compile the body of the :: operator as a function to properly handle closure.

Bump the compiler version to 26

I added tests for all the new behaviors