### PR TITLE
NEW: text_align allows to configure text alignment for Field

### DIFF
--- a/enaml/qt/qt_field.py
+++ b/enaml/qt/qt_field.py
@@ -9,7 +9,7 @@ from atom.api import Int, Typed
 
 from enaml.widgets.field import ProxyField
 
-from .QtCore import QTimer, Signal
+from .QtCore import QTimer, Signal, Qt
 from .QtWidgets import QLineEdit
 
 from .qt_control import QtControl
@@ -19,6 +19,12 @@ ECHO_MODES = {
     'normal': QLineEdit.Normal,
     'password': QLineEdit.Password,
     'silent': QLineEdit.NoEcho
+}
+
+ALIGN_OPTIONS = {
+    'left': Qt.AlignLeft,
+    'right': Qt.AlignRight,
+    'center': Qt.AlignCenter,
 }
 
 
@@ -76,6 +82,7 @@ class QtField(QtControl, ProxyField):
         self.set_max_length(d.max_length)
         self.set_read_only(d.read_only)
         self.set_submit_triggers(d.submit_triggers)
+        self.set_text_align(d.text_align)
         self.widget.textEdited.connect(self.on_text_edited)
 
     #--------------------------------------------------------------------------
@@ -231,6 +238,13 @@ class QtField(QtControl, ProxyField):
 
         """
         self.widget.setReadOnly(read_only)
+
+    def set_text_align(self, text_align):
+        """ Set the alignment for the text in the field.
+
+        """
+        qt_align = ALIGN_OPTIONS[text_align]
+        self.widget.setAlignment(qt_align)
 
     def field_text(self):
         """ Get the text stored in the widget.

--- a/enaml/widgets/field.py
+++ b/enaml/widgets/field.py
@@ -43,6 +43,9 @@ class ProxyField(ProxyControl):
     def set_read_only(self, read_only):
         raise NotImplementedError
 
+    def set_text_align(self, text_align):
+        raise NotImplementedError
+
     def field_text(self):
         raise NotImplementedError
 
@@ -115,6 +118,9 @@ class Field(Control):
     #: Whether or not the field is read only. Defaults to False.
     read_only = d_(Bool(False))
 
+    #: Alignment for the text inside the field. Defaults to 'left'.
+    text_align = d_(Enum('left', 'right', 'center'))
+
     #: How strongly a component hugs it's contents' width. Fields ignore
     #: the width hug by default, so they expand freely in width.
     hug_width = set_default('ignore')
@@ -126,7 +132,7 @@ class Field(Control):
     # Observers
     #--------------------------------------------------------------------------
     @observe('text', 'mask', 'submit_triggers', 'placeholder', 'echo_mode',
-        'max_length', 'read_only')
+        'max_length', 'read_only', 'text_align')
     def _update_proxy(self, change):
         """ An observer which sends state change to the proxy.
 

--- a/examples/widgets/field.enaml
+++ b/examples/widgets/field.enaml
@@ -1,0 +1,43 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2013, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+""" An example of the `Field` widget.
+
+The `Field` is the most simple and common text input widget.
+
+This example shows how to use the many properties of the `Field` widget.
+
+<< autodoc-me >>
+"""
+from enaml.widgets.api import Window, Field, Container, ObjectCombo, Label
+from enaml.layout.api import vbox, hbox, spacer, align
+
+
+enamldef Main(Window):
+    title = 'The Field widget'
+
+    Container:
+
+        constraints = [
+            vbox(
+                hbox(label, combo_align, spacer),
+                hbox(field, spacer),
+            ),
+            align('v_center', label, combo_align),
+            field.width == 300,
+        ]
+
+        Label: label:
+            text = 'text_align:'
+
+        ObjectCombo: combo_align:
+            items = ['left', 'right', 'center']
+            selected = 'left'
+
+        Field: field:
+            text = 'This is some text'
+            text_align << combo_align.selected


### PR DESCRIPTION
I'm adding the `text_align` member on the `Field` widget, which takes a enum of `left` (default), `right` or `center`. This feature has been requested and discussed on #248 .

Short/minimal example also provided.
