### PR TITLE
Get rid of a spurious print triggerred by setting super in DynamicScope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   # This will force qt to the last available version on PyPI so we first
   # uninstall the previously installed version
   - 'if [ $QT_VERSION -gt 4 ] && [ $QSCINTILLA -eq 1 ]; then
-         conda remove pyqt --yes
+         conda remove pyqt --yes;
          $PIP_INSTALL QScintilla;
      fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   # This will force qt to the last available version on PyPI so we first
   # uninstall the previously installed version
   - 'if [ $QT_VERSION -gt 4 ] && [ $QSCINTILLA -eq 1 ]; then
-         $conda remove pyqt --yes
+         conda remove pyqt --yes
          $PIP_INSTALL QScintilla;
      fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,11 @@ before_install:
      fi'
 
   # Install QScintilla for Qt5 if requested
-  # This will force qt to the last available version on PyPI and means that
-  # we will have two versions of qt at the same time but it seems to work fine
+  # This will force qt to the last available version on PyPI so we first
+  # uninstall the previously installed version
   - 'if [ $QT_VERSION -gt 4 ] && [ $QSCINTILLA -eq 1 ]; then
-         $PIP_INSTALL QScintilla pyqt5==5.9.2;
+         $conda remove pyqt --yes
+         $PIP_INSTALL QScintilla;
      fi'
 
   # Install the dev version of the other nucleic projects

--- a/enaml/src/declarative_function.cpp
+++ b/enaml/src/declarative_function.cpp
@@ -85,7 +85,9 @@ _Invoke( PyObject* func, PyObject* key, PyObject* self, PyObject* args,
                                       f_globals.get(),
                                       f_builtins.get(), 0 )
         );
-    if( PyMapping_SetItemString( scope.get(), "super", newref( super_disallowed ) ) == -1 )
+    // For some obscure reason PyMapping_SetItemString leads to a spurious print
+    // We use PyObject_SetItem instead
+    if( PyObject_SetItem( scope.get(), PyUnicode_FromString("super"), newref( super_disallowed ) ) == -1 )
         return py_bad_internal_call("Failed to set key super in dynamic scope");
 
     PyObjectPtr pkw( xnewref( kwargs ) );

--- a/enaml/src/declarative_function.cpp
+++ b/enaml/src/declarative_function.cpp
@@ -87,7 +87,7 @@ _Invoke( PyObject* func, PyObject* key, PyObject* self, PyObject* args,
         );
     // For some obscure reason PyMapping_SetItemString leads to a spurious print
     // We use PyObject_SetItem instead
-    if( PyObject_SetItem( scope.get(), PyUnicode_FromString("super"), newref( super_disallowed ) ) == -1 )
+    if( PyObject_SetItem( scope.get(), Py23Str_FromString("super"), newref( super_disallowed ) ) == -1 )
         return py_bad_internal_call("Failed to set key super in dynamic scope");
 
     PyObjectPtr pkw( xnewref( kwargs ) );


### PR DESCRIPTION
~~I identified the issue recently on Python 3.6. To reproduce run~~
```pytest tests\test_layout_container.py -s```

~~I must say I do not understand the fix.~~ @sccolbert ~~I could use your deep knowledge of the C API here~~. ~~This was due to some weird leftover in my working environment~~

Now using the branch to see if we can get the tests to pas on pyqt 5.10