### PR TITLE
ImageView: Add constraints to enforce the respect of aspect ratio when required

### DIFF
--- a/enaml/qt/qt_image_view.py
+++ b/enaml/qt/qt_image_view.py
@@ -263,3 +263,11 @@ class QtImageView(QtControl, ProxyImageView):
 
         """
         self.widget.setPreserveAspectRatio(preserve)
+
+    def get_aspect_ratio(self):
+        """Get the image aspect ratio from the pixmap.
+
+        """
+        pixmap = self.widget.pixmap()
+        pm_size = pixmap.size()
+        return pm_size.width()/pm_size.height()

--- a/enaml/widgets/image_view.py
+++ b/enaml/widgets/image_view.py
@@ -32,6 +32,9 @@ class ProxyImageView(ProxyControl):
     def set_preserve_aspect_ratio(self, preserve):
         raise NotImplementedError
 
+    def get_aspect_ratio(self):
+        raise NotImplementedError
+
 
 class ImageView(Control):
     """ A widget which can display an Image with optional scaling.
@@ -57,6 +60,15 @@ class ImageView(Control):
 
     #: A reference to the ProxyImageView object.
     proxy = Typed(ProxyImageView)
+
+    def layout_constraints(self):
+        """Add constraints to preserve the aspect ratio.
+
+        """
+        if self.proxy_is_active and self.preserve_aspect_ratio:
+            ratio = self.proxy.get_aspect_ratio()
+            return self.constraints + [self.width == ratio*self.height]
+        return self.constraints
 
     #--------------------------------------------------------------------------
     # Observers


### PR DESCRIPTION
Previously if the image was made smaller than the image size, the size hint (which reflects the image size before rescaling) was used by the parent container which led to oversized container. This patch fixes this.