### PR TITLE
Replace past/future with compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   # This will force qt to the last available version on PyPI and means that
   # we will have two versions of qt at the same time but it seems to work fine
   - 'if [ $QT_VERSION -gt 4 ] && [ $QSCINTILLA -eq 1 ]; then
-         $PIP_INSTALL QScintilla pyqt5==5.9.2;
+         $PIP_INSTALL QScintilla pyqt5==5.10.1;
      fi'
 
   # Install the dev version of the other nucleic projects

--- a/enaml/applib/live_editor_model.py
+++ b/enaml/applib/live_editor_model.py
@@ -9,14 +9,13 @@ import linecache
 import traceback
 from types import ModuleType
 
-from future.builtins import int
-from future.utils import exec_
 from atom.api import Atom, Str, Typed, observe
 
 import enaml
 from enaml.core.object import Object
 from enaml.core.enaml_compiler import EnamlCompiler
 from enaml.core.parser import parse
+from enaml.compat import exec_
 from enaml.widgets.widget import Widget
 
 try:

--- a/enaml/colors.py
+++ b/enaml/colors.py
@@ -10,12 +10,12 @@
 """
 from colorsys import hls_to_rgb
 import re
-from past.builtins import basestring
+
 
 from atom.api import Coerced
 
 from .colorext import Color
-
+from enaml.compat import basestring
 
 #: Regex sub-expressions used for building more complex expression.
 _int = r'\s*((?:\+|\-)?[0-9]+)\s*'

--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2018, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,8 +8,7 @@
 import sys
 import re
 import codecs
-
-IS_PY3 = sys.version_info >= (3,)
+from atom.compat import *
 
 USE_WORDCODE = sys.version_info >= (3, 6)
 
@@ -111,8 +110,8 @@ else:
                                 code.co_cellvars)
         return updated_code
 
-# Source file reading and encoding detection
 
+# Source file reading and encoding detection
 if IS_PY3:
     import tokenize
 
@@ -249,3 +248,21 @@ else:
         with open(filename, 'rU') as f:
             src = f.read()
         return src.decode(enc).encode('utf-8')
+
+
+if IS_PY3:
+    import builtins
+    exec_ = getattr(builtins, "exec")
+
+else:
+    def exec_(code, globs=None, locs=None):
+        """Execute code in a namespace."""
+        if globs is None:
+            frame = sys._getframe(1)
+            globs = frame.f_globals
+            if locs is None:
+                locs = frame.f_locals
+            del frame
+        elif locs is None:
+            locs = globs
+        exec("""exec code in globs, locs""")

--- a/enaml/core/declarative.py
+++ b/enaml/core/declarative.py
@@ -5,14 +5,13 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.utils import with_metaclass
-
 from atom.api import Event, Typed, Unicode
 from atom.datastructures.api import sortedmap
 
 from .declarative_meta import DeclarativeMeta
 from .expression_engine import ExpressionEngine
 from .object import Object, flag_generator, flag_property
+from enaml.compat import with_metaclass
 
 
 def d_(member, readable=True, writable=True, final=True):

--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -17,11 +17,10 @@ from collections import defaultdict, namedtuple
 from zipfile import ZipFile
 
 
-from future.utils import with_metaclass, exec_
-
 from .enaml_compiler import EnamlCompiler, COMPILER_VERSION
 from .parser import parse
-from ..compat import read_source, detect_encoding, update_code_co_filename
+from ..compat import (read_source, detect_encoding, update_code_co_filename,
+                      with_metaclass, exec_)
 
 
 # The magic number as symbols for the current Python interpreter. These

--- a/enaml/core/parser/base_lexer.py
+++ b/enaml/core/parser/base_lexer.py
@@ -8,10 +8,9 @@
 import os
 import tokenize
 
-from future.builtins import str
 import ply.lex as lex
 
-from ...compat import IS_PY3
+from ...compat import IS_PY3, str
 
 
 #------------------------------------------------------------------------------

--- a/enaml/core/parser/lexer3.py
+++ b/enaml/core/parser/lexer3.py
@@ -5,10 +5,8 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import bytes
-
 from .base_lexer import BaseEnamlLexer
-from ...compat import decode_escapes, encode_escapes
+from ...compat import decode_escapes, encode_escapes, bytes
 
 
 class Python3EnamlLexer(BaseEnamlLexer):

--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -5,12 +5,11 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from past.builtins import basestring
 from atom.api import Atom, atomref
 
 from .alias import Alias
 from .code_tracing import CodeTracer
-from ..compat import IS_PY3
+from ..compat import IS_PY3, basestring
 
 
 class SubscriptionObserver(object):

--- a/enaml/fonts.py
+++ b/enaml/fonts.py
@@ -8,11 +8,11 @@
 """ A utility module for dealing with CSS3 font strings.
 
 """
-from past.builtins import basestring
 
 from atom.api import Coerced
 
 from .fontext import Font, FontStyle, FontCaps
+from enaml.compat import basestring
 
 
 #: A mapping from CSS font style keyword to style enum

--- a/enaml/layout/constrainable.py
+++ b/enaml/layout/constrainable.py
@@ -7,8 +7,8 @@
 #------------------------------------------------------------------------------
 from abc import ABCMeta
 
-from future.utils import with_metaclass
 from atom.api import Atom, Constant, DefaultValue, Enum
+from enaml.compat import with_metaclass
 
 import kiwisolver as kiwi
 

--- a/enaml/layout/dock_layout.py
+++ b/enaml/layout/dock_layout.py
@@ -9,11 +9,10 @@ from collections import deque
 import sys
 import warnings
 
-from future.utils import with_metaclass
-from past.builtins import basestring
 from atom.api import Atom, Int, Bool, Coerced, Enum, List, Unicode
 
 from enaml.nodevisitor import NodeVisitor
+from enaml.compat import with_metaclass, basestring
 
 from .geometry import Rect
 

--- a/enaml/layout/linear_symbolic.py
+++ b/enaml/layout/linear_symbolic.py
@@ -8,7 +8,7 @@
 from abc import ABCMeta
 
 
-from future.utils import with_metaclass
+from enaml.compat import with_metaclass
 import kiwisolver as kiwi
 
 

--- a/enaml/layout/strength_member.py
+++ b/enaml/layout/strength_member.py
@@ -5,7 +5,6 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import int
 from atom.api import Validate, Value
 
 

--- a/enaml/qt/docking/q_dock_container.py
+++ b/enaml/qt/docking/q_dock_container.py
@@ -6,7 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import Typed, Bool
-from future.builtins import str
+from enaml.compat import str
 
 from enaml.qt.QtCore import Qt, QMargins, QPoint, QRect, QEvent, Signal
 from enaml.qt.QtGui import QIcon, QCursor

--- a/enaml/qt/docking/q_dock_item.py
+++ b/enaml/qt/docking/q_dock_item.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import str
+from enaml.compat import str
 from enaml.qt.QtCore import Qt, QRect, QSize, QPoint, QTimer, Signal
 from enaml.qt.QtWidgets import QApplication, QFrame, QLayout
 

--- a/enaml/qt/docking/q_dock_title_bar.py
+++ b/enaml/qt/docking/q_dock_title_bar.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import str
+from enaml.compat import str
 from enaml.qt.QtCore import Qt, QSize, QPoint, QMargins, Signal
 from enaml.qt.QtWidgets import (
     QWidget, QFrame, QLineEdit, QHBoxLayout, QSizePolicy

--- a/enaml/qt/docking/style_sheets.py
+++ b/enaml/qt/docking/style_sheets.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import str
+from enaml.compat import str
 
 #: The global dict of registered stylesheets. This dict should never be
 #: modified directly. Use the functions 'register_style_sheet' and

--- a/enaml/qt/docking/xbms.py
+++ b/enaml/qt/docking/xbms.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import bytes
+from enaml.compat import bytes
 from atom.api import Atom, Int, Bytes
 
 from enaml.qt.QtCore import QSize

--- a/enaml/qt/q_flow_layout.py
+++ b/enaml/qt/q_flow_layout.py
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 from abc import ABCMeta, abstractmethod
 
-from future.utils import with_metaclass
+from enaml.compat import with_metaclass
 
 from .QtCore import Qt, QSize, QRect
 from .QtWidgets import QLayout, QWidgetItem

--- a/enaml/qt/qt_ipython_console.py
+++ b/enaml/qt/qt_ipython_console.py
@@ -6,7 +6,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import Typed
-from future.utils import raise_from
 
 from enaml.widgets.ipython_console import ProxyIPythonConsole
 

--- a/enaml/runner.py
+++ b/enaml/runner.py
@@ -15,12 +15,10 @@ import os
 import sys
 import types
 
-from future.utils import exec_
-
 from enaml import imports
 from enaml.core.parser import parse
 from enaml.core.enaml_compiler import EnamlCompiler
-from enaml.compat import read_source
+from enaml.compat import read_source, exec_
 
 
 def main():

--- a/enaml/scintilla/scintilla.py
+++ b/enaml/scintilla/scintilla.py
@@ -6,13 +6,14 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 import uuid
-from future.builtins import str
+
 from atom.api import (
     Atom, Int, Constant, Enum, Event, Typed, List, ForwardTyped, Tuple,
     Unicode, observe, set_default
 )
 from enaml.image import Image
 from enaml.core.declarative import d_
+from enaml.compat import str
 from enaml.widgets.control import Control, ProxyControl
 
 

--- a/enaml/stdlib/dock_area_styles.enaml
+++ b/enaml/stdlib/dock_area_styles.enaml
@@ -14,10 +14,9 @@ developer is free to define their own styles completely from scratch, and
 ignore these styles in their entirety.
 
 """
-from future.builtins import str
-from past.builtins import basestring
 from atom.api import Atom, Typed, Unicode
 from enaml.core.template_ import Template
+from enaml.compat import str, basestring
 from enaml.styling import StyleSheet, Style, Setter
 
 

--- a/enaml/stdlib/fields.enaml
+++ b/enaml/stdlib/fields.enaml
@@ -10,7 +10,7 @@
 This is a library of Enaml components deriving from the builtin Field.
 
 """
-from future.builtins import str
+from enaml.compat import str
 from enaml.validator import RegexValidator, IntValidator, FloatValidator
 from enaml.widgets.field import Field
 

--- a/enaml/stdlib/message_box.enaml
+++ b/enaml/stdlib/message_box.enaml
@@ -6,8 +6,7 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 import sys
-from past.builtins import basestring
-
+from enaml.compat import basestring
 from enaml.core.dynamic_template import DynamicTemplate
 from enaml.image import Image
 from enaml.layout.layout_helpers import align, hbox, spacer

--- a/enaml/widgets/file_dialog.py
+++ b/enaml/widgets/file_dialog.py
@@ -5,13 +5,13 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import str
 from atom.api import (
     Enum, Bool, Callable, List, Unicode, Typed, ForwardTyped, Event
 )
 
 from enaml.application import deferred_call
 from enaml.core.declarative import d_
+from enaml.compat import str
 from .toolkit_object import ToolkitObject, ProxyToolkitObject
 
 

--- a/enaml/widgets/object_combo.py
+++ b/enaml/widgets/object_combo.py
@@ -5,13 +5,12 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from future.builtins import str
 from atom.api import (
     Bool, Callable, List, Value, Typed, ForwardTyped, set_default, observe
 )
 
 from enaml.core.declarative import d_
-
+from enaml.compat import str
 from .control import Control, ProxyControl
 
 

--- a/enaml/workbench/workbench.py
+++ b/enaml/workbench/workbench.py
@@ -7,8 +7,8 @@
 #------------------------------------------------------------------------------
 from collections import defaultdict
 
-from future.builtins import str
 from atom.api import Atom, Event, Typed
+from enaml.compat import str
 
 from .plugin import Plugin
 

--- a/examples/layout/advanced/factory_func.enaml
+++ b/examples/layout/advanced/factory_func.enaml
@@ -15,9 +15,11 @@ that a relayout is necessary.
 
 << autodoc-me >>
 """
-from future import standard_library
-standard_library.install_aliases()
-from itertools import zip_longest
+from enaml.compat import IS_PY3
+if IS_PY3:
+    from itertools import zip_longest
+else:
+    from itertools import izip_longest as zip_longest
 
 from enaml.core.api import Include
 from enaml.layout.api import align, grid, factory

--- a/examples/layout/advanced/override_layout_constraints.enaml
+++ b/examples/layout/advanced/override_layout_constraints.enaml
@@ -14,9 +14,11 @@ from a single expression would be difficult or impossible.
 
 << autodoc-me >>
 """
-from future import standard_library
-standard_library.install_aliases()
-from itertools import zip_longest
+from enaml.compat import IS_PY3
+if IS_PY3:
+    from itertools import zip_longest
+else:
+    from itertools import izip_longest as zip_longest
 
 from enaml.layout.api import align, grid
 from enaml.widgets.api import Window, Container, Field, Label, PushButton

--- a/examples/widgets/drag_and_drop.enaml
+++ b/examples/widgets/drag_and_drop.enaml
@@ -46,7 +46,7 @@ declarative functions are available:
 
 << autodoc-me >>
 """
-from future.builtins import bytes
+from enaml.compat import bytes
 from enaml.drag_drop import DragData, DropAction
 from enaml.layout.api import hbox, vbox, align, spacer
 from enaml.styling import StyleSheet, Style, Setter

--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,8 @@ setup(
     url='https://github.com/nucleic/enaml',
     description='Declarative DSL for building rich user interfaces in Python',
     long_description=open('README.rst').read(),
-    requires=['future', 'atom', 'PyQt', 'ply', 'kiwisolver', 'qtpy'],
-    install_requires=['setuptools', 'future', 'atom>=0.4.1', 'qtpy>=1.3',
+    requires=['atom', 'PyQt', 'ply', 'kiwisolver', 'qtpy'],
+    install_requires=['setuptools', 'atom>=0.4.2', 'qtpy>=1.3',
                       'kiwisolver>=1.0.0', 'ply>=3.4'],
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setup(
     description='Declarative DSL for building rich user interfaces in Python',
     long_description=open('README.rst').read(),
     requires=['atom', 'PyQt', 'ply', 'kiwisolver', 'qtpy'],
-    install_requires=['setuptools', 'atom>=0.4.2', 'qtpy>=1.3',
+    install_requires=['setuptools', 'atom>=0.4.2.dev', 'qtpy>=1.3',
                       'kiwisolver>=1.0.0', 'ply>=3.4'],
     packages=find_packages(),
     package_data={

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -8,10 +8,9 @@
 #------------------------------------------------------------------------------
 from ast import literal_eval
 from textwrap import dedent
-from future.utils import exec_
 
 from utils import compile_source
-from enaml.compat import IS_PY3
+from enaml.compat import IS_PY3, exec_
 
 
 def test_unicode_literal():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,11 +8,10 @@
 import os
 import sys
 import types
-from time import sleep
 
 import pytest
 
-from future.utils import exec_
+from enaml.compat import exec_
 
 from enaml import imports
 from enaml.core.parser import parse

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,7 +41,7 @@ else:
 try:
     try:
         from PyQt4 import Qsci
-    except:
+    except Exception:
         from PyQt5 import Qsci
 except ImportError:
     SCINTILLA_AVAILABLE = False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,10 +10,10 @@
 """
 from contextlib import contextmanager
 
-from future.utils import exec_
 from atom.api import Atom, Bool
 
 import enaml
+from enaml.compat import exec_
 from enaml.application import timed_call
 from enaml.core.enaml_compiler import EnamlCompiler
 from enaml.core.parser import parse


### PR DESCRIPTION
Depends on the proposed changes for atom.

The `exec_` function was pulled from the `future` library the others are in the atom PR.

