### PR TITLE
Significant re-write to Installation instructions

### DIFF
--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -119,15 +119,6 @@ instructions for adding the package to your system.
 .. _Setuptools Install: https://pypi.python.org/pypi/setuptools/1.1.6
 .. _Pip Install: https://pip.pypa.io/en/stable/installing/
 
-`Future`_
-~~~~~~~~~
-
-Enaml supports both Python 2 and 3 and uses the future library as a 
-compatibility layer. Future can be installed with the ``pip install`` command 
-of `Pip`_::
-
-    $ pip install future
-
 `Ply`_
 ~~~~~~
 

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -10,12 +10,13 @@ choose from.
 Anaconda: The Easiest Way
 -------------------------
 
-If you use the `Anaconda`_ Python distribution platform, you the latest 
+If you use the `Anaconda`_ Python distribution platform (or `Miniconda`_, its lighter-weight companion), the latest 
 release of Enaml can be installed using conda from the conda-forge channel::
     
     $ conda install enaml -c conda-forge
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda
+.. _Miniconda: https://conda.io/miniconda.html
 
 Wheels: The Pretty Easy Way
 ---------------------------
@@ -33,7 +34,7 @@ Python
 ~~~~~~
 
 Enaml is a Python framework and requires a supported Python runtime. Enaml
-currently supports **Python 2.7**, **Python 3.4**, **Python 3.5**,
+currently supports **Python 2.7**, **Python 3.4**, **Python 3.5**, and
 **Python 3.6**.
 
 The most recent Python releases are available on the `Python Downloads`_ pages.
@@ -59,9 +60,6 @@ Enaml's declarative widgets provide a layer of abstraction on top of the
 widgets of a toolkit rendering library. You will need to install this
 dependency separately.
 
-Enaml supports using either PyQt4 or PyQt5 and uses the `QtPy`_ library
-as compatibility layer.
-
 The recommended library is `PyQt5`_,  a robust set of Python bindings to the
 Qt 5 toolkit.  (It includes the necessary parts of Qt 5.)
 
@@ -69,25 +67,39 @@ On 32 and 64-bit Windows, 64-bit OS X and 64-bit Linux, with Python
 versions >=3.5, it can be installed via pip::
 
     $ pip install pyqt5
+    
+.. note::
+    There is no pyqt5 wheel available for 32-bit Linux.
 
-An alternative is _PyQt_, which is a robust set of Python bindings to the 
-Qt 4 toolkit. It is no longer a supported project, but can still be installed
-and used with Enaml. The `PyQt Downloads`_ page contains Windows installers
-- which also the necessary parts of Qt 4. OSX users can install PyQt4 via
-`Homebrew`_. Linux users should install via the system package manager.
+Alternatives
+++++++++++++
 
-Another alternative is `PySide`_ bindings to Qt. This is not recommended. The
-PySide bindings are not nearly as stable as PyQt. They contain several bugs
-which can and will cause applications to crash. There are also some API
-differences between the two libraries. So while some effort is made to
-support the use of PySide in Enaml, it is "use at your own risk".
+Enaml uses the `QtPy`_ library as compatibility layer to support some other QT-based libraries.
 
-To activate PySide support, install PySide or PySide2 separately and set the
-environment variable ``QT_API=pyside`` (``QT_API=pyside2`` for PySide2)
-before starting the Enaml application.
+* `PyQt`_, which is a robust set of Python bindings to the Qt 4 toolkit. It is no longer a 
+  supported project, but can still be installed and used with Enaml. The 
+  `PyQt Downloads`_ page contains Windows installers - which also the necessary parts of Qt 4.
+  OSX users can install PyQt4 via `Homebrew`_. Linux users should install via the system
+  package manager.
 
-While Enaml is architected to be toolkit agnostic, the use of anything but
-`Qt`_-based toolkit libraries is not recommended.
+* `PySide2`_ (a.k.a. Qt for Python) is a set of Python bindings to the Qt 5 toolkit.
+  This is not recommended. These bindings are not nearly as stable as PyQt. They contain
+  several bugs which can and will cause applications to crash. There are also some API
+  differences between the two libraries.  While some effort is made to support the use of
+  PySide2 in Enaml, it is "use at your own risk". Patches to improve support are welcomed.
+
+  To activate PySide2 support, install `PySide2`_ separately and set the environment 
+  variable ``QT_API=pyside2`` before starting the Enaml application.
+
+* `PySide`_ is a set of Python bindings to the Qt 4 toolkit which are no longer being
+  maintained. These bindings are not recommended, and not supported, but you may find they
+  work anyway. Use at your own risk.
+
+  To activate PySide support, install `PySide`_ separately and set the environment 
+  variable ``QT_API=pyside`` before starting the Enaml application.
+
+* While Enaml is architected to be toolkit agnostic, only Qt-based toolkit libraries are
+  supported. There are third-party projects that provide support for other back-ends.
 
 Compiling it yourself: The Hard Way
 -----------------------------------
@@ -99,7 +111,6 @@ assume that the user's system has a C++ compiler and the `Git`_ command line
 tools installed and available on the system path.
 
 .. _Git: http://git-scm.com
-
 
 `Setuptools`_ and `Pip`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,6 +161,7 @@ QtPy can be installed with the ``pip install`` command of `Pip`_::
 .. _PyQt Downloads: http://www.riverbankcomputing.com/software/pyqt/download
 .. _Homebrew: http://brew.sh
 .. _PySide: http://qt-project.org/wiki/PySide
+.. _Pyside2: http://wiki.qt.io/Qt_for_Python
 
 `Kiwisolver`_
 ~~~~~~~~~~~~~
@@ -159,7 +171,7 @@ optimizer. This is the same algorithm used by the Cocoa Autolayout engine in
 OSX. Kiwisolver provides Python bindings to a C++ implementation of the
 Cassowary algorithm.
 
-The simplest way to install Kiwisolver is with ``pip``::
+Kiwisolver can be installed with the ``pip install`` command of `Pip`_::
 
     $ pip install kiwisolver
 

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -4,46 +4,33 @@
 Installation
 ============
 
-Installing Enaml is a straight forward process. It requires few external
-dependencies, and those which are required are easily installed, with most
-projects providing binaries or a simple Python setup script. The sections
-below describe how to install Enaml and all of its dependencies from scratch,
-starting with the installation of a Python runtime. The instructions assume
-that the user's system has a C++ compiler and the `Git`_ command line tools
-installed and available on the system path.
+Installing Enaml is a straight-forward process. There are three approaches to
+choose from.
 
-.. _Git: http://git-scm.com
+Anaconda: The Easiest Way
+-------------------------
 
-
-.. topic:: The Easy Way
-
-    If installing and building Enaml and its dependencies from scratch is not
-    appealing, the free (and unaffiliated) `Anaconda`_ Python distribution
-    provides a complete Python environment in which the last release of Enaml
-    can be installed using conda from the conda-forge channel::
+If you use the `Anaconda`_ Python distribution platform, you the latest 
+release of Enaml can be installed using conda from the conda-forge channel::
     
     $ conda install enaml -c conda-forge
-    
-    If you have a working C++ compiler, you can install using pip::
-
-    $ pip install enaml
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda
 
+Wheels: The Pretty Easy Way
+---------------------------
 
-.. topic:: Supported Platforms
+If you don't use Anaconda, you can install Enaml and its dependencies,
+pre-compiled, through PIP, for most common platforms.
 
-    Enaml is known to run on Windows, OSX, and Linux; and compiles cleanly
-    with MSVC, Clang, GCC, and MinGW. However, primary development of the
-    framework occurs on Windows (7, 8 and 10), so some quirks and bugs may be
-    present on the other platforms. If you encounter a bug, please report
-    it on the `Issue Tracker`_.
+You will need three things:
+  
+* `Python`_
+* Enaml (and its dependencies)
+* a toolkit rendering library
 
-.. _Issue Tracker: http://github.com/nucleic/enaml/issues
-
-
-`Python`_
----------
+Python
+~~~~~~
 
 Enaml is a Python framework and requires a supported Python runtime. Enaml
 currently supports **Python 2.7**, **Python 3.4**, **Python 3.5**,
@@ -57,8 +44,65 @@ using their OS package manager.
 .. _Python Downloads: http://python.org/download
 
 
+Enaml and Dependencies
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can install enaml and (almost) all of its dependencies through the pip
+command line.::
+
+    $ pip install enaml
+
+Toolkit Rendering Library
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enaml's declarative widgets provide a layer of abstraction on top of the
+widgets of a toolkit rendering library. You will need to install this
+dependency separately.
+
+Enaml supports using either PyQt4 or PyQt5 and uses the `QtPy`_ library
+as compatibility layer.
+
+The recommended library is `PyQt5`_,  a robust set of Python bindings to the
+Qt 5 toolkit.  (It includes the necessary parts of Qt 5.)
+
+On 32 and 64-bit Windows, 64-bit OS X and 64-bit Linux, with Python 
+versions >=3.5, it can be installed via pip::
+
+    $ pip install pyqt5
+
+An alternative is _PyQt_, which is a robust set of Python bindings to the 
+Qt 4 toolkit. It is no longer a supported project, but can still be installed
+and used with Enaml. The `PyQt Downloads`_ page contains Windows installers
+- which also the necessary parts of Qt 4. OSX users can install PyQt4 via
+`Homebrew`_. Linux users should install via the system package manager.
+
+Another alternative is `PySide`_ bindings to Qt. This is not recommended. The
+PySide bindings are not nearly as stable as PyQt. They contain several bugs
+which can and will cause applications to crash. There are also some API
+differences between the two libraries. So while some effort is made to
+support the use of PySide in Enaml, it is "use at your own risk".
+
+To activate PySide support, install PySide or PySide2 separately and set the
+environment variable ``QT_API=pyside`` (``QT_API=pyside2`` for PySide2)
+before starting the Enaml application.
+
+While Enaml is architected to be toolkit agnostic, the use of anything but
+`Qt`_-based toolkit libraries is not recommended.
+
+Compiling it yourself: The Hard Way
+-----------------------------------
+
+Building Enaml from scratch requires a few external dependencies. The
+sections below describe how to install Enaml and all of its dependencies from
+scratch, starting with the installation of a Python runtime. The instructions
+assume that the user's system has a C++ compiler and the `Git`_ command line
+tools installed and available on the system path.
+
+.. _Git: http://git-scm.com
+
+
 `Setuptools`_ and `Pip`_
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setuptools is a Python package which makes installing other Python packages a
 breeze. Pip is the default package manager for Python. The installation 
@@ -67,7 +111,6 @@ target Python environment. Follow the relevant `Setuptools Install`_
 instructions for adding the package to your system.
 
 .. note::
-
     Recent versions of Python (Python 2 >=2.7.9 or Python 3 >=3.4) installed 
     from the official binaries install come with those tools installed.
 
@@ -76,19 +119,17 @@ instructions for adding the package to your system.
 .. _Setuptools Install: https://pypi.python.org/pypi/setuptools/1.1.6
 .. _Pip Install: https://pip.pypa.io/en/stable/installing/
 
-
 `Future`_
----------
+~~~~~~~~~
 
 Enaml supports both Python 2 and 3 and uses the future library as a 
 compatibility layer. Future can be installed with the ``pip install`` command 
 of `Pip`_::
 
-    C:\> pip install future
-
+    $ pip install future
 
 `Ply`_
-------
+~~~~~~
 
 The Enaml framework extends the grammar Python language with new declarative
 syntax constructs. To accomplish this, Enaml has a fully compliant Python 
@@ -98,51 +139,29 @@ implementations of lex and yacc.
 
 Ply can be installed with the ``pip install`` command of `Pip`_::
 
-    C:\> pip install ply
+    $ pip install ply
+
+`QtPy`_
+~~~~~~
+
+The Enaml framework uses the `QtPy`_ library as a compatibility shim between
+the various toolkit rendering libraries.
+
+QtPy can be installed with the ``pip install`` command of `Pip`_::
+
+    $ pip install QtPy
 
 .. _Ply: http://www.dabeaz.com/ply
-
-
-`PyQt`_
--------
-
-Enaml's declarative widgets provide a layer of abstraction on top of the
-widgets of a toolkit rendering library. While Enaml is architected to be
-toolkit agnostic, the recommended toolkit library is `Qt`_.
-
-Enaml supports using either PyQt4 or PyQt5 and uses the `qtpy`_ library
-as compatibility layer.
-
-PyQt4 is a robust set of Python bindings to the Qt 4 toolkit.
-The `PyQt Downloads`_ page contains Windows installers which include the Qt
-binaries. OSX users can install PyQt4 via `Homebrew`_. Linux users should
-install via the system package manager.
-
-PyQt5 is a robust set of Python bindings to the Qt 5 toolkit. On Python 3,
-it can install via pip::
-
-$ pip install pyqt5
-
-.. topic:: Note for PySide/PySide2 Users
-
-    Enaml has unofficial support for using the `PySide`_ bindings to Qt. To
-    activate PySide support, set the environment variable ``QT_API=pyside``
-    (``QT_API=pyside2`` for PySide2) before starting the Enaml application.
-    Note that the PySide bindings are not nearly as stable as PyQt and contain
-    several bugs which can and will cause applications to crash. There are also
-    some API differences between the two libraries. So while some effort is
-    made to support the use of PySide in Enaml, it is "use at your own risk".
-
 .. _PyQt: http://www.riverbankcomputing.com/software/pyqt/intro
-.. _qtpy: https://pypi.python.org/pypi/QtPy/
+.. _PyQt5: https://pypi.org/project/PyQt5/
+.. _QtPy: https://pypi.python.org/pypi/QtPy/
 .. _Qt: http://qt-project.org
 .. _PyQt Downloads: http://www.riverbankcomputing.com/software/pyqt/download
 .. _Homebrew: http://brew.sh
 .. _PySide: http://qt-project.org/wiki/PySide
 
-
 `Kiwisolver`_
--------------
+~~~~~~~~~~~~~
 
 Enaml's layout engine is built on top of the `Cassowary`_ linear constraint
 optimizer. This is the same algorithm used by the Cocoa Autolayout engine in
@@ -151,14 +170,13 @@ Cassowary algorithm.
 
 The simplest way to install Kiwisolver is with ``pip``::
 
-    C:\> pip install kiwisolver
+    $ pip install kiwisolver
 
 .. _Kiwisolver: https://github.com/nucleic/kiwi
 .. _Cassowary: http://www.cs.washington.edu/research/constraints/cassowary
 
-
 `Atom`_
--------
+~~~~~~~
 
 Atom is the Python framework which provides the foundational object model for
 Enaml. Atom objects are extremely lightweight, fast, and support a robust
@@ -168,22 +186,32 @@ the development of Atom.
 
 Cloning and building Atom from source is simple::
 
-    C:\> git clone https://github.com/nucleic/atom.git
-    C:\> cd atom
-    C:\> python setup.py install
+    $ git clone https://github.com/nucleic/atom.git
+    $ cd atom
+    $ python setup.py install
 
 .. _Atom: https://github.com/nucleic/atom
 .. _Observer Pattern: http://en.wikipedia.org/wiki/Observer_pattern
 
-
 `Enaml`_
---------
+~~~~~~~~
 
-The last item on the list is Enaml itself, and it can be installed with just
-a few commands::
+The last item on the list is Enaml itself. The latest (unstable dev) version
+can be installed with just a few commands::
 
-    C:\> git clone https://github.com/nucleic/enaml.git
-    C:\> cd enaml
-    C:\> python setup.py install
+    $ git clone https://github.com/nucleic/enaml.git
+    $ cd enaml
+    $ python setup.py install
 
 .. _Enaml: https://github.com/nucleic/enaml
+
+Supported Platforms
+-------------------
+
+Enaml is known to run on Windows, OSX, and Linux; and compiles cleanly
+with MSVC, Clang, GCC, and MinGW. However, primary development of the
+framework occurs on Windows (7, 8 and 10), so some quirks and bugs may be
+present on the other platforms. If you encounter a bug, please report
+it on the `Issue Tracker`_.
+
+.. _Issue Tracker: http://github.com/nucleic/enaml/issues


### PR DESCRIPTION
Based on recent experience as newbie, I have proposed a restructure of the Installation instructions.

* Clearly separate out the three methods.
* Make it clearer you can install without a C++ compiler on most platforms - pip install isn't much harder than Anaconda.
* Group the toolkit rendering libraries together and make recommendations clearer.
* Mention that you need to install QtPy (if doing it manually).
* Standardise on a command prompt ($ over C:\>, rather arbitrarily.)