### PR TITLE
Add WebView example and another dock layout test

### DIFF
--- a/examples/widgets/web_view.enaml
+++ b/examples/widgets/web_view.enaml
@@ -1,0 +1,27 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2018, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+""" 
+
+This example shows how to use a WebView. 
+
+<< autodoc-me >>
+"""
+from enaml.widgets.api import Window, Container, WebView
+
+
+# Note: QtWebEngineWidgets must be imported before the QtApplication is started
+# or it will throw an import error
+from enaml.qt import QtWebEngineWidgets
+
+
+enamldef Main(Window):
+    initial_size = (480, 960)
+    Container:
+        padding = 0
+        WebView:
+            url = 'https://enaml.readthedocs.org'

--- a/examples/widgets/web_view.enaml
+++ b/examples/widgets/web_view.enaml
@@ -9,13 +9,14 @@
 
 This example shows how to use a WebView. 
 
+Note: QtWebEngineWidgets must be imported before the QtApplication is started 
+on Qt 5.10+ or an ImportError will be thrown.
+
 << autodoc-me >>
 """
 from enaml.widgets.api import Window, Container, WebView
 
-
-# Note: QtWebEngineWidgets must be imported before the QtApplication is started
-# or it will throw an import error
+# Only needed for Qt 5.10+
 from enaml.qt import QtWebEngineWidgets
 
 

--- a/tests/test_dock_layout.py
+++ b/tests/test_dock_layout.py
@@ -75,10 +75,12 @@ def test_validation_dock_layout2(enaml_qtbot, enaml_sleep):
 def test_dock_area_interactions(enaml_qtbot, enaml_sleep):
     """Test interations with the dock area.
 
-    14013 lines
-
     """
-    from enaml.qt.QtCore import Qt
+    # Since timers are used the sleep must be greater than the default
+    enaml_sleep = 300
+    from enaml.qt.QtCore import Qt, QPoint
+    from enaml.qt.QtWidgets import QWidget
+    from enaml.layout.api import FloatItem, InsertTab
     with open(os.path.join('examples', 'widgets', 'dock_area.enaml')) as f:
         source = f.read()
     
@@ -92,8 +94,6 @@ def test_dock_area_interactions(enaml_qtbot, enaml_sleep):
         
     # Enable dock events
     enaml_qtbot.mouseClick(cbx_evts.proxy.widget, Qt.LeftButton)
-    
-    enaml_sleep = 1000
     enaml_qtbot.wait(enaml_sleep)
     
     with pytest.warns(DockLayoutWarning):
@@ -138,6 +138,47 @@ def test_dock_area_interactions(enaml_qtbot, enaml_sleep):
         
         # Unpin
         enaml_qtbot.mouseClick(tb._pin_button, Qt.LeftButton)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Note the location of the dock item title
+        title = tb._title_label
+        ref = win.proxy.widget
+        
+        # Maximize and minimize it by double clicking
+        pos = title.mapTo(tb, title.pos())
+        enaml_qtbot.mouseDClick(tb, Qt.LeftButton, pos=pos)
+        enaml_qtbot.wait(enaml_sleep)
+        enaml_qtbot.mouseDClick(tb, Qt.LeftButton, pos=pos)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Float it
+        op = FloatItem(item=di.name)
+        dock.update_layout(op)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Link it
+        enaml_qtbot.mouseClick(tb._link_button, Qt.LeftButton)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Unlink it
+        enaml_qtbot.mouseClick(tb._link_button, Qt.LeftButton)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Restore it
+        op = InsertTab(item=di.name, target='item_1')
+        dock.update_layout(op)
+        enaml_qtbot.wait(enaml_sleep)
+        
+        # Drag it around
+        # TODO: this doesn't currently drag the window. It seems like QTest
+        # doesn't propagate events like "normal" mouse input does.
+        pos = title.mapTo(tb, title.pos())
+        enaml_qtbot.mousePress(tb, Qt.LeftButton, pos=pos)
+        for i in range(0, dock_area.size().width(), 100):
+            for j in range(0, dock_area.size().height(), 100):
+               pos = QPoint(i, j)
+               enaml_qtbot.mouseMove(ref, pos)
+               enaml_qtbot.wait(int(enaml_sleep/10))
         enaml_qtbot.wait(enaml_sleep)
         
         # Add items

--- a/tests/test_dock_layout.py
+++ b/tests/test_dock_layout.py
@@ -77,7 +77,7 @@ def test_dock_area_interactions(enaml_qtbot, enaml_sleep):
 
     """
     # Since timers are used the sleep must be greater than the default
-    enaml_sleep = 300
+    enaml_sleep = max(300, enaml_sleep)
     from enaml.qt.QtCore import Qt, QPoint
     from enaml.qt.QtWidgets import QWidget
     from enaml.layout.api import FloatItem, InsertTab
@@ -169,17 +169,7 @@ def test_dock_area_interactions(enaml_qtbot, enaml_sleep):
         dock.update_layout(op)
         enaml_qtbot.wait(enaml_sleep)
         
-        # Drag it around
-        # TODO: this doesn't currently drag the window. It seems like QTest
-        # doesn't propagate events like "normal" mouse input does.
-        pos = title.mapTo(tb, title.pos())
-        enaml_qtbot.mousePress(tb, Qt.LeftButton, pos=pos)
-        for i in range(0, dock_area.size().width(), 100):
-            for j in range(0, dock_area.size().height(), 100):
-               pos = QPoint(i, j)
-               enaml_qtbot.mouseMove(ref, pos)
-               enaml_qtbot.wait(int(enaml_sleep/10))
-        enaml_qtbot.wait(enaml_sleep)
+        # TODO: Drag it around
         
         # Add items
         enaml_qtbot.mouseClick(btn_add.proxy.widget, Qt.LeftButton)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -56,6 +56,14 @@ except ImportError:
 else:
     VTK_AVAILABLE = True
 
+
+try:
+    from enaml.qt import QtWebEngineWidgets
+    WEBVIEW_AVAILABLE = True
+except ImportError:
+    WEBVIEW_AVAILABLE = False
+
+
 if is_qt_available():
     try:
         import enaml.qt.qt_ipython_console
@@ -192,6 +200,10 @@ def handle_window_closing(qtbot, window):
                                        marks=pytest.mark.skipif(
                                            not VTK_AVAILABLE,
                                            reason='Requires vtk')),
+                          pytest.param('widgets/web_view.enaml', None,
+                                       marks=pytest.mark.skipif(
+                                           not WEBVIEW_AVAILABLE,
+                                           reason='Requires webview')),
                           ('widgets/window_children.enaml', None),
                           ('widgets/window_closing.enaml',
                            handle_window_closing),


### PR DESCRIPTION
Want to add an example for the WebView to note that the QtWebEngineWidgets must be imported before the QtApplication is started.  qtpy currently clobbers the import error that mentions this and it takes time to find this.  It's imported in the example so it works when using enaml-run.

Also added a test for dock interactions. I would like to also get it to cover the some of the drag and drop code but QTest doesn't seem to support this very well.