### PR TITLE
Updates lexer/parser to allow using def for declarative functions

### DIFF
--- a/enaml/core/parser/base_parser.py
+++ b/enaml/core/parser/base_parser.py
@@ -779,7 +779,7 @@ class BaseEnamlParser(object):
     def p_decl_funcdef1(self, p):
         ''' decl_funcdef : NAME NAME parameters COLON suite '''
         lineno = p.lineno(1)
-        if p[1] != 'func':
+        if p[1] not in ('func', 'def'):
             syntax_error('invalid syntax', FakeToken(p.lexer.lexer, lineno))
         funcdef = ast.FunctionDef()
         funcdef.name = p[2]

--- a/enaml/core/parser/lexer3.py
+++ b/enaml/core/parser/lexer3.py
@@ -123,7 +123,7 @@ class Python36EnamlLexer(Python35EnamlLexer):
         """
         if 'f' in quote_type.lower():
             if 'r' not in quote_type.lower():
-                string =  decode_escapes(string)
+                string = decode_escapes(string)
             return string, 'FSTRING'
         return super(Python36EnamlLexer, self).format_string(string,
                                                              quote_type)

--- a/examples/functions/declare_function.enaml
+++ b/examples/functions/declare_function.enaml
@@ -32,11 +32,15 @@ enamldef Main(Window): m:
         print([[i for i in range(1)] for i in range(2)])
         print([m for i in range(3) if i == m])
         print('Index', i)
+        
+    def on_sbox_changed():
+        print(sbox.value)
 
     Container:
         SpinBox: sbox:
             maximum = 100
             minimum = 0
+            value :: on_sbox_changed()
         PushButton:
             text = 'Click Me'
             clicked ::


### PR DESCRIPTION
Retains backwards compatibility by accepting either `func` or `def` when defining a declarative func. It does not do anything with overrides.

I tested it by using find and replace in an existing project with both sync and async functions.