### PR TITLE
Add documentation for tools directory.

### DIFF
--- a/docs/source/dev_guides/index.rst
+++ b/docs/source/dev_guides/index.rst
@@ -14,6 +14,7 @@ the framework see the :ref:`arch_ref`.
     :hidden:
 
     stylesheets
+    languagebasedtools
     workbenches
 
 .. This simply prevents the :doc: to create entries in the sidebar
@@ -25,6 +26,12 @@ the framework see the :ref:`arch_ref`.
     customize the visual appearance of a view independent from the
     view's structural definition. Inspired by CSS, but with all the
     dynamism provided by the Enaml language.
+
+    .. rubric:: :doc:`languagebasedtools`
+
+    Enaml introduces a new syntax. Language-based tools can be
+    configured to recognise this syntax. Several such configurations and
+    plug-ins are provided.
 
     .. rubric:: :doc:`workbenches`
 

--- a/docs/source/dev_guides/languagebasedtools.rst
+++ b/docs/source/dev_guides/languagebasedtools.rst
@@ -1,0 +1,138 @@
+.. _languagebasedtools:
+
+====================
+Language-Based Tools
+====================
+
+Language-based tools are software that operate on programming languages,
+including Integrated Development Environments (IDEs) and others.
+
+Many of these tools can be configured to recognise the syntax of a .enaml file,
+and thus provide syntax-colouring, indenting support and other features.
+
+Enaml comes bundled with a number of configuration files for common IDEs and
+other tools.
+
+`BBEdit`_
+----------------------------
+
+BBEdit is a commercial MacOS IDE from `Bare Bones`_.
+
+An Enaml language library for BBEdit is provided in the source at
+``tools/barebones/``
+
+For installation instructions, see the `BBEdit Support pages`_.
+
+.. _BBEdit: https://www.barebones.com/products/bbedit/
+.. _Bare Bones: https://www.barebones.com/
+.. _BBEdit Support pages: https://www.barebones.com/support/bbedit/plugin_library.html
+
+`GNU Emacs`_
+------------
+
+GNU Emacs is a popular, cross-platform, open-source IDE.
+
+An Enaml mode for Emacs is provided in the source at ``tools/emacs``.
+
+For installation instructions, see in the source at
+``tools/emacs/README.rst``
+
+.. _GNU Emacs: https://www.gnu.org/software/emacs/
+
+`TextMate`_
+-----------
+
+TextMate is a commercial MacOS IDE.
+
+An Enaml language definition for TextMate is provided in the source tree at
+``tools/sublimetext``.
+
+
+For installation instructions, see the `TextMate Manual`_.
+
+.. _TextMate: https://macromates.com/
+.. _TextMate Manual: https://macromates.com/manual/en/language_grammars#language_grammars
+
+`Sublime Text`_
+---------------
+
+Sublime Text is a cross-platform, commercial IDE.
+
+Sublime Text can also use the TextMate language definition at
+``tools/sublimetext/Enaml.tmLanguage``.
+
+For installation instructions, see the `Sublime Text manual`_.
+
+.. _Sublime Text: https://www.sublimetext.com/
+.. _Sublime Text manual: http://docs.sublimetext.info/en/latest/extensibility/packages.html#installing-packages
+
+
+`Visual Studio`_
+----------------
+
+Visual Studio is a commercial IDE for Windows and MacOs from Microsoft.
+
+Visual Studio can also use the TextMate language definition at
+``tools/sublimetext/Enaml.tmLanguage``.
+
+For installation instructions, see the
+`Visual Studio manual`_.
+
+.. _Visual Studio: https://visualstudio.microsoft.com/
+.. _Visual Studio manual: https://code.visualstudio.com/docs/extensions/themes-snippets-colorizers
+
+`PyCharm`_
+----------------
+
+
+PyCharm is a cross-platform, freemium Python IDE from JetBrains.
+
+PyCharm can also use the TextMate language definition at
+``tools/sublimetext/Enaml.tmLanguage``.
+
+For installation instructions, see the `TextMate Bundles support plugin`_
+manual.
+
+Alternatively, there are two third-party PyCharm plugins to add basic syntax
+support for Enaml:
+
+* `pycharm-enaml-plugin`_
+* `pycharm-enaml-keywords`_
+
+.. warning::
+    These third-party plugins are not supported by the Enaml team.
+
+.. _PyCharm: https://www.jetbrains.com/pycharm/
+.. _TextMate Bundles support plugin: https://www.jetbrains.com/help/pycharm/2018.1/tutorial-using-textmate-bundles.html
+.. _pycharm-enaml-plugin: https://github.com/pberkes/pycharm-enaml-plugin
+.. _pycharm-enaml-keywords: https://github.com/vahndi/pycharm-enaml-keywords
+
+`Vim`_
+------
+Vim is a popular, cross-platform, charityware text editor.
+
+Enaml syntax and indent files are available at ``tools/vim``.
+
+For installation instructions, see in the source at
+``tools/vim/README.rst``
+
+.. _Vim: https://www.vim.org/
+
+`Pygments`_
+-----------
+
+Pygments is an open-source generic syntax highlighter. It is used by
+`Sphinx`_ to format code included in project documentation.
+
+An Enaml lexer for Pygments is available at ``tools/pygments``.
+
+To install, change into the ``./tools/pygments`` directory, and run
+``python setup.py install``.
+
+Once this is installed, it will be automatically used by Sphinx to format
+Enaml code blocks (i.e. `code directives`_, with `enaml` as the language
+argument.)
+
+.. _Pygments: http://pygments.org/
+.. _Sphinx: http://www.sphinx-doc.org/
+.. _code directives: http://docutils.sourceforge.net/docs/ref/rst/directives.html#Code

--- a/docs/source/dev_guides/languagebasedtools.rst
+++ b/docs/source/dev_guides/languagebasedtools.rst
@@ -78,8 +78,17 @@ Visual Studio can also use the TextMate language definition at
 For installation instructions, see the
 `Visual Studio manual`_.
 
+Alternatively, there is a third-party Visual Studio extension, `enaml-vs`_ available
+free from the Visual Studio Marketplace, which offers simpler installation of the 
+same definitions.
+
 .. _Visual Studio: https://visualstudio.microsoft.com/
 .. _Visual Studio manual: https://code.visualstudio.com/docs/extensions/themes-snippets-colorizers
+.. _enaml-vs: https://marketplace.visualstudio.com/items?itemName=mdartiailh.enaml-vs
+
+.. warning::
+    Third-party plugins are not supported by the Enaml team.
+
 
 `PyCharm`_
 ----------------
@@ -100,7 +109,7 @@ support for Enaml:
 * `pycharm-enaml-keywords`_
 
 .. warning::
-    These third-party plugins are not supported by the Enaml team.
+    Third-party plugins are not supported by the Enaml team.
 
 .. _PyCharm: https://www.jetbrains.com/pycharm/
 .. _TextMate Bundles support plugin: https://www.jetbrains.com/help/pycharm/2018.1/tutorial-using-textmate-bundles.html

--- a/docs/source/get_started/introduction.rst
+++ b/docs/source/get_started/introduction.rst
@@ -19,26 +19,26 @@ for the framework.
 What is Enaml?
 --------------
 
-*Fundamentally*
+*Fundamentally:*
 
-    Enaml is a declarative extension to the Python language grammar which
-    enables a developer to concisely define a hierarchical tree of objects
-    which automatically react to changes in a data model.
+Enaml is a declarative extension to the Python language grammar which
+enables a developer to concisely define a hierarchical tree of objects
+which automatically react to changes in a data model.
 
-*Practically*
+*Practically:*
 
-    Enaml is one of the easiest and most powerful ways to build professional
-    quality user interfaces with Python.
+Enaml is one of the easiest and most powerful ways to build
+professional-quality user interfaces with Python.
 
 
 Traditional UIs
 ---------------
 
 Traditional user interface frameworks are typically implemented in a low level
-language like C or C++. This is because the frameworks utilize the libraries
+language like C or C++. The frameworks utilize the libraries
 and services provided by the underlying operating system in order to draw
 pixels on the screen. These low-level drawing operations are abstracted from
-the developer with high level easy-to-use APIs. Some UI frameworks can be used
+the developer with high-level easy-to-use APIs. Some UI frameworks can be used
 from Python with the help of wrappers which expose the high level toolkit APIs
 to the Python runtime. The most common of these frameworks and their Python
 wrappers include:
@@ -58,12 +58,8 @@ wrappers include:
 .. _Tk: http://www.tcl.tk
 .. _TkInter: https://wiki.python.org/moin/TkInter
 
-All of these frameworks share a common theme which is:
-
-.. highlights::
-
-    A user interface is constructed as a tree of graphical objects with
-    some associated state.
+All of these frameworks share a common theme: *A user interface is constructed
+as a tree of graphical objects with some associated state.*
 
 Consider a hypothetical abstract object hierarchy, and what it might look like
 if converted into a typical UI window:
@@ -77,7 +73,7 @@ if converted into a typical UI window:
         :align: center
 
 In order to create such a window, most frameworks require the developer to
-write imperative code to setup up the window's object hierachy. This leads to
+write imperative code to set up the window's object hierarchy. This leads to
 code which looks similar to the following Python snippet:
 
 .. code-block:: python
@@ -112,10 +108,8 @@ The problem with code like this is that its structure does not map well to
 the objects which it is producing. The code is tedious to read, write, and
 understand; which makes it error-prone and difficult to maintain.
 
-.. highlights::
-
-    Imperative programming constructs are simply not well suited for defining
-    nested object hierarchies.
+**Imperative programming constructs are simply not well suited for defining
+nested object hierarchies.**
 
 Programming against these frameworks is a fairly low level task and procedural
 task. A developer is responsible for:
@@ -140,8 +134,8 @@ Relatively recently, there has been a shift in the UI development paradigm
 which places an emphasis on the declarative specification of the object
 hierarchy. The developer provides a declarative representation of the UI and
 defines how the visual elements of the UI should bind to data in data models;
-the framework then takes responsibity for updating the UI when the data in the
-data models change, and vice versa.
+the framework then takes responsibility for updating the UI when the data in
+the data models change, and vice versa.
 
 This paradigm solves the primary problems with the imperative model:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,11 +9,11 @@ platform which supports Python and Qt.
 
 A few highlights of the framework:
 
-    * A declarative language which extends the grammar of Python
-    * A set of operators which automatically track runtime dependencies
-    * A layout system which uses symbolic constraint declarations
-    * A design which encourages model-view separation
-    * A well documented and easy to follow code base
+* A declarative language which extends the grammar of Python
+* A set of operators which automatically track runtime dependencies
+* A layout system which uses symbolic constraint declarations
+* A design which encourages model-view separation
+* A well documented and easy to follow code base
 
 
 .. toctree::
@@ -30,46 +30,46 @@ A few highlights of the framework:
 :doc:`get_started/index`
 ------------------------
 
-    The first stop for all those new to Enaml. This section includes
-    an introduction to Enaml, installation instructions, and all the
-    information needed to write your first Enaml application.
+The first stop for all those new to Enaml. This section includes
+an introduction to Enaml, installation instructions, and all the
+information needed to write your first Enaml application.
 
 :doc:`dev_guides/index`
 -----------------------
 
-    The stuff that wasn't covered in :doc:`get_started/index`. This
-    section provides in-depth documentation on a wide range of topics
-    you are likely to encounter when developing production applications
-    with Enaml. Look here for details on Enaml's scoping rules, aliases,
-    templates, best practices, and more.
+The stuff that wasn't covered in :doc:`get_started/index`. This
+section provides in-depth documentation on a wide range of topics
+you are likely to encounter when developing production applications
+with Enaml. Look here for details on Enaml's scoping rules, aliases,
+templates, best practices, and more.
 
 
 :doc:`arch_ref/index`
 ---------------------
 
-    Hackers welcome! This section offers a collection of topics covering
-    the low level details of Enaml's architecture and implementation.
-    Look here if you want to understand how Enaml works internally, or
-    if you are interested in extending Enaml for your own custom needs.
+Hackers welcome! This section offers a collection of topics covering
+the low level details of Enaml's architecture and implementation.
+Look here if you want to understand how Enaml works internally, or
+if you are interested in extending Enaml for your own custom needs.
 
 :doc:`examples/index`
 ---------------------
 
-    "Just show me the code!" This section provides an easy-to-browse
-    alternative to running Enaml's examples from the command line. We've
-    even included screenshots!
+"Just show me the code!" This section provides an easy-to-browse
+alternative to running Enaml's examples from the command line. We've
+even included screenshots!
 
 :doc:`faqs/index`
 -----------------
 
-    If you think you may not be the only one to have thought a thought,
-    you are probably right. Look here to see if your question has
-    already been asked, then take solace in the realization that you are
-    not alone.
+If you think you may not be the only one to have thought a thought,
+you are probably right. Look here to see if your question has
+already been asked, then take solace in the realization that you are
+not alone.
 
 :doc:`api_ref/index`
 --------------------
 
-    "Use the source, Luke." When all else fails, consult the API docs to
-    find the answer you need. The API docs also include convenient links
-    to the most definitive Enaml documentation: the source.
+"Use the source, Luke." When all else fails, consult the API docs to
+find the answer you need. The API docs also include convenient links
+to the most definitive Enaml documentation: the source.


### PR DESCRIPTION
**Main Change**

There is a tools folder which is undocumented.  It contains various definitions for syntax-based tools so they can handle `.enaml` files.

This commit adds a new page to the Developer's Guide explaining how these definitions can be used in a long list of popular IDEs and also the Pygments lexer required for generating documentation.

**Bonus Extra**

Formatting, spelling and grammar improvements on a couple of the main RST files.