### PR TITLE
Run Appveyor tests on Python 3.7.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,31 +13,39 @@ environment:
         #    Enaml supports Python 2.7 and also 3.4 onwards.
         #    PyQt4 only available for Python <3.6.
         #    PyQt5 only available for Python >=3.5.
-        #       PyQt5 version 5.11.2 doesn't run on Python 3.5.
         #    PySide1 only available for 2.6 <= Python <=3.4. Wheels only for 32-bit.
-        
+        #    Miniconda does not run on Python 3.7 yet.
+
         # Strategy:
         #    Test each 64-bit Python version, but only the latest known patch.
-        #    Test the oldest and the latest 32-bit Python versions release. 
-        #    Test with PyQt4 where available, otherwise PyQT5 in each version.
+        #    Test the oldest and the latest 32-bit Python versions release.
+        #    Test with PyQt4 where available, otherwise PyQt5 in each version.
         #    Test QScintilla on latest Python version available.
-        #    Test Pyside1 in latest Python version it runs on.
+        #    Test PySide1 in latest Python version it runs on.
         #        - Failure is allowed and won't block PRs.
-        #    Test Pyside2 in latest Python version available
+        #    Test PySide2 in latest Python version available
         #        - Failure is allowed and won't block PRs.
         #    Only test single toolkit installs (e.g. not QT4 and QT5 on same install)
-        
+
         # VARIABLES
         #    NAME: just a comment for distinguishing builds in Appveyor.
+        #    MINICONDA: Path of Minicode binaries.
         #    PYQT_VERSION: Determines PyQt versions installation
-        #    PY_QT: Determines Pyside version installation (if present), and is used by 
+        #    PY_QT: Determines Pyside version installation (if present), and is used by
         #           Enaml.
         #    PYTEST_QT_API: In Python 3.4, pytest-qt needs a hint about the right interface.
         #    QSCINTILLA: Set to "Yes" to install it.
-        
+
 
         # 64-bit versions, PyQT, latest to oldest.
-        
+
+        - NAME: "Py 3.7"
+          PYTHON: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.7.0"
+          PYTHON_ARCH: "64"
+          MINICONDA: C:\Miniconda36-x64
+          PYQT_VERSION: "5"
+
         - NAME: "Py 3.6"
           PYTHON: "C:\\Python36-x64"
           PYTHON_VERSION: "3.6.3"
@@ -77,10 +85,10 @@ environment:
           PYQT_VERSION: "4"
 
         # 32-bit versions, PyQT, latest to oldest.
-        
+
         - NAME: "32-bit, Latest "
-          PYTHON: "C:\\Python36"
-          PYTHON_VERSION: "3.6.3"
+          PYTHON: "C:\\Python37"
+          PYTHON_VERSION: "3.7.0"
           PYTHON_ARCH: "32"
           MINICONDA: C:\Miniconda36
           PYQT_VERSION: "5"
@@ -95,8 +103,8 @@ environment:
         # QScintilla
 
         - NAME: "QScintilla"
-          PYTHON: "C:\\Python36-x64"
-          PYTHON_VERSION: "3.6.3"
+          PYTHON: "C:\\Python37-x64"
+          PYTHON_VERSION: "3.7.0"
           PYTHON_ARCH: "64"
           MINICONDA: C:\Miniconda36-x64
           PYQT_VERSION: "5"
@@ -115,8 +123,8 @@ environment:
           QT_API: "pyside"
 
         - NAME: "PySide2"
-          PYTHON: "C:\\Python36-x64"
-          PYTHON_VERSION: "3.6.3"
+          PYTHON: "C:\\Python37-x64"
+          PYTHON_VERSION: "3.7.0"
           PYTHON_ARCH: "64"
           MINICONDA: C:\Miniconda36-x64
           PYQT_VERSION: "None"
@@ -129,7 +137,7 @@ matrix:
      # Errors are monitored, but should not stop PRs being delivered.
      - QT_API: "pyside"
      - QT_API: "pyside2"
-        
+
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -141,14 +149,14 @@ install:
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
-  
+
   # Dump some debugging information about the machine.
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""
-  
+
   - ECHO "Build Folder:"
   - ps: ls $env:APPVEYOR_BUILD_FOLDER
-  
+
   - ECHO "Environment Variables"
   - set
 
@@ -172,7 +180,7 @@ install:
   - conda upgrade -q pip setuptools
   # Conda on Py3.4 doesn't upgrade it. Try to push the point.
   - python -m pip install -U pip
-  
+
   # Allow the building of wheels.
   - conda install -q wheel
 
@@ -181,7 +189,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print('Architecture is win'+str(struct.calcsize('P') * 8))\""
   - pip --version
-  
+
   # At the time of writing, the setup.py says Enaml depends on a dev version
   # of Atom which is not on PyPI. Install straight from GitHub.
   - pip install https://github.com/nucleic/atom/tarball/master
@@ -189,9 +197,7 @@ install:
   # We need a library for Qt.
   # PyQT4 won't pip install, so resort to conda.
   - if %PYQT_VERSION%==4 conda install -q pyqt=4
-  # Pyqt5 5.11.2 doesn't work on Python 3.5 (although it does on other versions)
-  # Avoid using it for now, but optimistically assume that they will fix in next release.
-  - if %PYQT_VERSION%==5 pip install pyqt5!=5.11.2
+  - if %PYQT_VERSION%==5 pip install pyqt5
   - ps: if ($env:QT_API -eq "pyside") {pip install PySide}  
   # Pyside2 won't pip install, so resort to conda.
   - ps: if ($env:QT_API -eq "pyside2") {conda config --add channels conda-forge; conda install -q pyside2}


### PR DESCRIPTION
Addresses one of the requirements for #287.

* Miniconda doesn't have a Python 3.7 version yet.
* PyQt5 5.11.2 was improperly built for Python 3.5. Looks like they fixed the problem without incrementing the version number.
* Minor spelling and spacing improvements.

