### PR TITLE
Add CloseEvent to DockItem

### DIFF
--- a/enaml/qt/qt_dialog.py
+++ b/enaml/qt/qt_dialog.py
@@ -7,8 +7,8 @@
 #------------------------------------------------------------------------------
 from atom.api import Typed, atomref
 
-from enaml.widgets.dialog import ProxyDialog
 from enaml.widgets.close_event import CloseEvent
+from enaml.widgets.dialog import ProxyDialog
 
 from .QtCore import Qt
 from .QtWidgets import QDialog

--- a/enaml/qt/qt_dialog.py
+++ b/enaml/qt/qt_dialog.py
@@ -8,7 +8,7 @@
 from atom.api import Typed, atomref
 
 from enaml.widgets.dialog import ProxyDialog
-from enaml.widgets.window import CloseEvent
+from enaml.widgets.close_event import CloseEvent
 
 from .QtCore import Qt
 from .QtWidgets import QDialog

--- a/enaml/qt/qt_dock_item.py
+++ b/enaml/qt/qt_dock_item.py
@@ -8,6 +8,7 @@
 from atom.api import Int, Typed
 
 from enaml.styling import StyleCache
+from enaml.widgets.close_event import CloseEvent
 from enaml.widgets.dock_item import ProxyDockItem
 
 from .QtCore import Qt, QSize, Signal
@@ -30,8 +31,14 @@ class QCustomDockItem(QDockItem):
 
     def closeEvent(self, event):
         """ Handle the close event for the dock item.
-
         """
+        d_event = CloseEvent()
+        d = self._proxy_ref.declaration
+        d.closing(d_event)
+        if not d_event.is_accepted():
+            event.ignore()
+            return
+
         super(QCustomDockItem, self).closeEvent(event)
         if event.isAccepted():
             self.closed.emit()
@@ -59,6 +66,7 @@ class QtDockItem(QtWidget, ProxyDockItem):
 
         """
         self.widget = QCustomDockItem(self.parent_widget())
+        self.widget._proxy_ref = self
 
     def init_widget(self):
         """ Initialize the state of the underlying widget.

--- a/enaml/qt/qt_main_window.py
+++ b/enaml/qt/qt_main_window.py
@@ -9,8 +9,8 @@ import sys
 
 from atom.api import Typed, atomref
 
-from enaml.widgets.main_window import ProxyMainWindow
 from enaml.widgets.close_event import CloseEvent
+from enaml.widgets.main_window import ProxyMainWindow
 
 from .QtCore import Qt
 from .QtWidgets import QMainWindow

--- a/enaml/qt/qt_main_window.py
+++ b/enaml/qt/qt_main_window.py
@@ -10,7 +10,7 @@ import sys
 from atom.api import Typed, atomref
 
 from enaml.widgets.main_window import ProxyMainWindow
-from enaml.widgets.window import CloseEvent
+from enaml.widgets.close_event import CloseEvent
 
 from .QtCore import Qt
 from .QtWidgets import QMainWindow

--- a/enaml/qt/qt_window.py
+++ b/enaml/qt/qt_window.py
@@ -10,7 +10,8 @@ import sys
 from atom.api import Typed, atomref
 
 from enaml.layout.geometry import Pos, Rect, Size
-from enaml.widgets.window import ProxyWindow, CloseEvent
+from enaml.widgets.window import ProxyWindow
+from enaml.widgets.close_event import CloseEvent
 
 from .QtCore import Qt, QPoint, QRect, QSize
 from .QtGui import QIcon

--- a/enaml/qt/qt_window.py
+++ b/enaml/qt/qt_window.py
@@ -10,8 +10,8 @@ import sys
 from atom.api import Typed, atomref
 
 from enaml.layout.geometry import Pos, Rect, Size
-from enaml.widgets.window import ProxyWindow
 from enaml.widgets.close_event import CloseEvent
+from enaml.widgets.window import ProxyWindow
 
 from .QtCore import Qt, QPoint, QRect, QSize
 from .QtGui import QIcon

--- a/enaml/widgets/close_event.py
+++ b/enaml/widgets/close_event.py
@@ -1,0 +1,35 @@
+from atom.api import Atom, Bool
+
+
+class CloseEvent(Atom):
+    """ An payload object carried by a widget 'closing' event.
+
+    User code can manipulate this object to veto a close event.
+
+    """
+    #: The internal accepted state.
+    _accepted = Bool(True)
+
+    def is_accepted(self):
+        """ Get whether or not the event is accepted.
+
+        Returns
+        -------
+        result : bool
+            True if the event is accepted, False otherwise. The
+            default is True.
+
+        """
+        return self._accepted
+
+    def accept(self):
+        """ Accept the close event and allow the widget to be closed.
+
+        """
+        self._accepted = True
+
+    def ignore(self):
+        """ Reject the close event and prevent the widget from closing.
+
+        """
+        self._accepted = False

--- a/enaml/widgets/close_event.py
+++ b/enaml/widgets/close_event.py
@@ -1,3 +1,10 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2013-2017, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
 from atom.api import Atom, Bool
 
 

--- a/enaml/widgets/dock_item.py
+++ b/enaml/widgets/dock_item.py
@@ -14,6 +14,7 @@ from enaml.core.declarative import d_
 from enaml.icon import Icon
 from enaml.layout.geometry import Size
 
+from .close_event import CloseEvent
 from .container import Container
 from .widget import Widget, ProxyWidget
 
@@ -80,6 +81,13 @@ class DockItem(Widget):
 
     #: An event emitted when the title bar is right clicked.
     title_bar_right_clicked = d_(Event(), writable=False)
+
+    #: An event fired when the user request the dock item to be closed.
+    #: This will happen when the user clicks on the "X" button in the
+    #: title bar button, or when the 'close' method is called. The
+    #: payload will be a CloseEvent object which will allow code to
+    #: veto the close event and prevent the item from closing.
+    closing = d_(Event(CloseEvent), writable=False)
 
     #: An event emitted when the dock item is closed. The item will be
     #: destroyed after this event has completed.

--- a/enaml/widgets/window.py
+++ b/enaml/widgets/window.py
@@ -15,6 +15,7 @@ from enaml.icon import Icon
 from enaml.layout.geometry import Pos, Rect, Size
 
 from .container import Container
+from .close_event import CloseEvent
 from .widget import Widget, ProxyWidget
 
 
@@ -87,40 +88,6 @@ class ProxyWindow(ProxyWidget):
 
     def close(self):
         raise NotImplementedError
-
-
-class CloseEvent(Atom):
-    """ An payload object carried by a window 'closing' event.
-
-    User code can manipulate this object to veto a close event.
-
-    """
-    #: The internal accepted state.
-    _accepted = Bool(True)
-
-    def is_accepted(self):
-        """ Get whether or not the event is accepted.
-
-        Returns
-        -------
-        result : bool
-            True if the event is accepted, False otherwise. The
-            default is True.
-
-        """
-        return self._accepted
-
-    def accept(self):
-        """ Accept the close event and allow the window to be closed.
-
-        """
-        self._accepted = True
-
-    def ignore(self):
-        """ Reject the close event and prevent the window from closing.
-
-        """
-        self._accepted = False
 
 
 class Window(Widget):

--- a/enaml/widgets/window.py
+++ b/enaml/widgets/window.py
@@ -14,8 +14,8 @@ from enaml.core.declarative import d_
 from enaml.icon import Icon
 from enaml.layout.geometry import Pos, Rect, Size
 
-from .container import Container
 from .close_event import CloseEvent
+from .container import Container
 from .widget import Widget, ProxyWidget
 
 

--- a/examples/widgets/dock_area.enaml
+++ b/examples/widgets/dock_area.enaml
@@ -21,6 +21,7 @@ from enaml.layout.api import (
     HSplitLayout, VSplitLayout, TabLayout, InsertItem, hbox, vbox, spacer
 )
 from enaml.stdlib.dock_area_styles import available_styles
+from enaml.stdlib.message_box import question
 from enaml.widgets.api import (
     Window, Container, DockArea, DockItem, PushButton, Field, Html, Slider,
     ObjectCombo, CheckBox, MultilineField
@@ -29,6 +30,16 @@ from enaml.widgets.api import (
 
 def cap_case(name):
     return ' '.join(s.capitalize() for s in name.split('-'))
+
+
+def confirm_close(window, event):
+    button = question(
+        window, 'Dock item closing', 'Are you sure you want to close this dock item?'
+    )
+    if button and button.action == 'accept':
+        event.accept()
+    else:
+        event.ignore()
 
 
 class LineCollector(Atom):
@@ -87,6 +98,8 @@ enamldef MyDockArea(DockArea):
             Field: pass
             Field: pass
             Field: pass
+        closing ::
+            confirm_close(self, change['value'])
     DockItem:
         name = 'item_2'
         title = 'Item 2'


### PR DESCRIPTION
This will allow DockItem widgets to perform an action in response to the titlebar close button being clicked (and ignore this event if desired).