### PR TITLE
Fix order of text in generated .pdf file

### DIFF
--- a/docs/source/dev_guides/index.rst
+++ b/docs/source/dev_guides/index.rst
@@ -10,13 +10,6 @@ variety of topics ranging from language features and syntax rules to
 application development and best practices. For the implementation details of
 the framework see the :ref:`arch_ref`.
 
-.. toctree::
-    :hidden:
-
-    stylesheets
-    languagebasedtools
-    workbenches
-
 .. This simply prevents the :doc: to create entries in the sidebar
 .. container::
 
@@ -36,6 +29,13 @@ the framework see the :ref:`arch_ref`.
     .. rubric:: :doc:`workbenches`
 
     Enaml Workbenches provide a set of low-level components which can
-    be used to develop high-level plugin applications.  Workbenches 
-    enable the developer to write large UI applications which can be 
+    be used to develop high-level plugin applications.  Workbenches
+    enable the developer to write large UI applications which can be
     *safely extended at runtime* by other developers.
+
+.. toctree::
+    :hidden:
+
+    stylesheets
+    languagebasedtools
+    workbenches

--- a/docs/source/get_started/index.rst
+++ b/docs/source/get_started/index.rst
@@ -11,16 +11,6 @@ When you are comfortable with the topics here, have a look at the
 :ref:`dev_guides` for in-depth articles about developing with the framework.
 
 
-.. toctree::
-    :titlesonly:
-    :hidden:
-
-    introduction
-    installation
-    anatomy
-    syntax
-    layout
-
 .. This simply prevents the :doc: to create entries in the sidebar
 .. container::
 
@@ -59,3 +49,14 @@ When you are comfortable with the topics here, have a look at the
     become tedious for all but the simplest of cases. Enaml sheds the
     status quo and provides a flexible layout system which uses symbolic
     constraints. This section covers the basics of constraints layout.
+
+
+.. toctree::
+    :titlesonly:
+    :hidden:
+
+    introduction
+    installation
+    anatomy
+    syntax
+    layout


### PR DESCRIPTION
Currently, in the generated .pdf file, the toctree gets expanded before the reader's guide of the Getting Started chapter (i.e. the reader's guide ends up on pp. 18 and 19).
I'm not well-versed into sphinx, so I don't know if this change actually does fix that order...