### PR TITLE
Add button group widget

### DIFF
--- a/docs/source/api_ref/widgets/button_group.rst
+++ b/docs/source/api_ref/widgets/button_group.rst
@@ -1,0 +1,15 @@
+.. module:: enaml.widgets.button_group
+
+==========================
+enaml.widgets.button_group
+==========================
+
+.. rubric:: Classes
+
+.. autosummary::
+    :nosignatures:
+
+    ButtonGroup
+
+
+.. autoclass:: ButtonGroup

--- a/docs/source/api_ref/widgets/index.rst
+++ b/docs/source/api_ref/widgets/index.rst
@@ -13,6 +13,7 @@ enaml.widgets
     bounded_date <bounded_date>
     bounded_datetime <bounded_datetime>
     bounded_time <bounded_time>
+    button_group <button_group>
     calendar <calendar>
     check_box <check_box>
     color_dialog <color_dialog>
@@ -86,6 +87,7 @@ enaml.widgets
     bounded_date
     bounded_datetime
     bounded_time
+    button_group
     calendar
     check_box
     color_dialog

--- a/enaml/qt/qt_abstract_button.py
+++ b/enaml/qt/qt_abstract_button.py
@@ -33,6 +33,7 @@ class QtAbstractButton(QtControl, ProxyAbstractButton):
     #: A reference to the widget created by the proxy
     widget = Typed(QAbstractButton)
 
+    #: A reference to the group this button is part of.
     _current_group = Typed(ButtonGroup)
 
     #: Cyclic notification guard. This a bitfield of multiple guards.
@@ -118,6 +119,14 @@ class QtAbstractButton(QtControl, ProxyAbstractButton):
             self.widget.setIconSize(QSize(*size))
 
     def set_group(self, group):
+        """Set the group this button belongs to.
+
+        Parameters
+        ----------
+        group : ButtonGroup
+            ButtonGroup declaration to which this button should be added.
+
+        """
         if self._current_group:
             self._current_group.proxy.remove_button(self.declaration)
         group.proxy.add_button(self.declaration)

--- a/enaml/qt/qt_abstract_button.py
+++ b/enaml/qt/qt_abstract_button.py
@@ -8,6 +8,7 @@
 from atom.api import Int, Typed
 
 from enaml.widgets.abstract_button import ProxyAbstractButton
+from enaml.widgets.button_group import ButtonGroup
 
 from .QtCore import QSize
 from .QtGui import QIcon
@@ -31,6 +32,8 @@ class QtAbstractButton(QtControl, ProxyAbstractButton):
     """
     #: A reference to the widget created by the proxy
     widget = Typed(QAbstractButton)
+
+    _current_group = Typed(ButtonGroup)
 
     #: Cyclic notification guard. This a bitfield of multiple guards.
     _guard = Int(0)
@@ -56,6 +59,8 @@ class QtAbstractButton(QtControl, ProxyAbstractButton):
             self.set_icon(d.icon)
         if -1 not in d.icon_size:
             self.set_icon_size(d.icon_size)
+        if d.group:
+            self.set_group(d.group)
         self.set_checkable(d.checkable)
         self.set_checked(d.checked)
         widget = self.widget
@@ -111,6 +116,12 @@ class QtAbstractButton(QtControl, ProxyAbstractButton):
         """
         with self.geometry_guard():
             self.widget.setIconSize(QSize(*size))
+
+    def set_group(self, group):
+        if self._current_group:
+            self._current_group.proxy.remove_button(self.declaration)
+        group.proxy.add_button(self.declaration)
+        self._current_group = group
 
     def set_checkable(self, checkable):
         """ Sets whether or not the widget is checkable.

--- a/enaml/qt/qt_button_group.py
+++ b/enaml/qt/qt_button_group.py
@@ -1,3 +1,10 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2019, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
 from atom.api import Typed
 from enaml.widgets.button_group import ProxyButtonGroup
 
@@ -7,22 +14,42 @@ from .qt_toolkit_object import QtToolkitObject
 
 
 class QtButtonGroup(QtToolkitObject, ProxyButtonGroup):
+    """ A Qt implementation of the Enaml ProxyButtonGroup.
+
+    """
+
+    #: A reference to the widget created by the proxy
     widget = Typed(QButtonGroup)
 
     def create_widget(self):
+        """ Create the button group widget.
+
+        """
         self.widget = QButtonGroup(self.parent_widget())
 
     def init_widget(self):
+        """ Initialize the button group widget.
+
+        """
         super(QtButtonGroup, self).init_widget()
 
         d = self.declaration
         self.set_exclusive(d.exclusive)
 
     def set_exclusive(self, exclusive):
+        """ Make the button group exclusive or not.
+
+        """
         self.widget.setExclusive(exclusive)
 
     def add_button(self, button):
+        """ Add a button to the group.
+
+        """
         self.widget.addButton(button.proxy.widget)
 
     def remove_button(self, button):
+        """ Remove a button from the group.
+
+        """
         self.widget.removeButton(button.proxy.widget)

--- a/enaml/qt/qt_button_group.py
+++ b/enaml/qt/qt_button_group.py
@@ -1,0 +1,28 @@
+from atom.api import Typed
+from enaml.widgets.button_group import ProxyButtonGroup
+
+from .QtWidgets import QButtonGroup
+
+from .qt_toolkit_object import QtToolkitObject
+
+
+class QtButtonGroup(QtToolkitObject, ProxyButtonGroup):
+    widget = Typed(QButtonGroup)
+
+    def create_widget(self):
+        self.widget = QButtonGroup(self.parent_widget())
+
+    def init_widget(self):
+        super(QtButtonGroup, self).init_widget()
+
+        d = self.declaration
+        self.set_exclusive(d.exclusive)
+
+    def set_exclusive(self, exclusive):
+        self.widget.setExclusive(exclusive)
+
+    def add_button(self, button):
+        self.widget.addButton(button.proxy.widget)
+
+    def remove_button(self, button):
+        self.widget.removeButton(button.proxy.widget)

--- a/enaml/qt/qt_factories.py
+++ b/enaml/qt/qt_factories.py
@@ -15,6 +15,11 @@ def action_group_factory():
     return QtActionGroup
 
 
+def button_group_factory():
+    from .qt_button_group import QtButtonGroup
+    return QtButtonGroup
+
+
 def calendar_factory():
     from .qt_calendar import QtCalendar
     return QtCalendar
@@ -303,6 +308,7 @@ def window_factory():
 QT_FACTORIES = {
     'Action': action_factory,
     'ActionGroup': action_group_factory,
+    'ButtonGroup': button_group_factory,
     'Calendar': calendar_factory,
     'CheckBox': check_box_factory,
     'ColorDialog': color_dialog_factory,

--- a/enaml/widgets/abstract_button.py
+++ b/enaml/widgets/abstract_button.py
@@ -16,6 +16,11 @@ from enaml.layout.geometry import Size
 from .control import Control, ProxyControl
 
 
+def ButtonGroup():
+    from .button_group import ButtonGroup
+    return ButtonGroup
+
+
 class ProxyAbstractButton(ProxyControl):
     """ The abstract definition of a proxy AbstractButton object.
 
@@ -30,6 +35,9 @@ class ProxyAbstractButton(ProxyControl):
         raise NotImplementedError
 
     def set_icon_size(self, size):
+        raise NotImplementedError
+
+    def set_group(self, group):
         raise NotImplementedError
 
     def set_checkable(self, checkable):
@@ -52,6 +60,8 @@ class AbstractButton(Control):
     #: The size to use for the icon. The default is an invalid size
     #: and indicates that an appropriate default should be used.
     icon_size = d_(Coerced(Size, (-1, -1)))
+
+    group = d_(ForwardTyped(ButtonGroup))
 
     #: Whether or not the button is checkable. The default is False.
     checkable = d_(Bool(False))
@@ -78,7 +88,7 @@ class AbstractButton(Control):
     #--------------------------------------------------------------------------
     # Observers
     #--------------------------------------------------------------------------
-    @observe('text', 'icon', 'icon_size', 'checkable', 'checked')
+    @observe('text', 'icon', 'icon_size', 'group', 'checkable', 'checked')
     def _update_proxy(self, change):
         """ An observer which updates the proxy widget.
 

--- a/enaml/widgets/abstract_button.py
+++ b/enaml/widgets/abstract_button.py
@@ -61,6 +61,7 @@ class AbstractButton(Control):
     #: and indicates that an appropriate default should be used.
     icon_size = d_(Coerced(Size, (-1, -1)))
 
+    #: Group to which this button belongs to.
     group = d_(ForwardTyped(ButtonGroup))
 
     #: Whether or not the button is checkable. The default is False.

--- a/enaml/widgets/abstract_button.py
+++ b/enaml/widgets/abstract_button.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013, Nucleic Development Team.
+# Copyright (c) 2013-2019, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -86,6 +86,12 @@ class AbstractButton(Control):
     #: A reference to the ProxyAbstractButton object.
     proxy = Typed(ProxyAbstractButton)
 
+    def __init__(self, parent=None, **kwargs):
+        super(AbstractButton, self).__init__(parent, **kwargs)
+        # Overridden to synchronize the group_members member of the group
+        if self.group:
+            self.group.group_members.add(self)
+
     #--------------------------------------------------------------------------
     # Observers
     #--------------------------------------------------------------------------
@@ -96,3 +102,15 @@ class AbstractButton(Control):
         """
         # The superclass implementation is sufficient.
         super(AbstractButton, self)._update_proxy(change)
+
+    #--------------------------------------------------------------------------
+    # Post Setattr Handlers
+    #--------------------------------------------------------------------------
+    def _post_setattr_group(self, old, new):
+        """ Update the group_members of the group this button belongs too.
+
+        """
+        if old:
+            old.group_members.remove(self)
+        if new:
+            new.group_members.add(self)

--- a/enaml/widgets/api.py
+++ b/enaml/widgets/api.py
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------
 from .action import Action
 from .action_group import ActionGroup
+from .button_group import ButtonGroup
 from .calendar import Calendar
 from .check_box import CheckBox
 from .color_dialog import ColorDialog

--- a/enaml/widgets/button_group.py
+++ b/enaml/widgets/button_group.py
@@ -32,10 +32,14 @@ class ProxyButtonGroup(ProxyToolkitObject):
 class ButtonGroup(ToolkitObject):
     """ A way to declare a group of buttons.
 
-    This allows to group buttons even though they beloing to different
-    container.
+    This allows to group buttons even though they belong to different
+    container. Note that if a button belongs to a ButtonGroup the rules
+    about buttons sharing a container being in the same group do not apply.d2
 
     """
+    #: Set of members belonging to the group.
+    #: This value should be considered read-only for users.
+    group_members = Typed(set, ())
 
     #: Can only a single button in the group be checked at a time.
     exclusive = d_(Bool(True))

--- a/enaml/widgets/button_group.py
+++ b/enaml/widgets/button_group.py
@@ -1,3 +1,10 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2019, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
 from atom.api import Bool, ForwardTyped, Typed, observe
 
 from enaml.core.declarative import d_
@@ -6,6 +13,10 @@ from .toolkit_object import ToolkitObject, ProxyToolkitObject
 
 
 class ProxyButtonGroup(ProxyToolkitObject):
+    """ The abstract defintion of a proxy ButtonGroup object.
+
+    """
+    #: A reference to the ButtonGroup declaration.
     declaration = ForwardTyped(lambda: ButtonGroup)
 
     def set_exclusive(self, exclusive):
@@ -19,18 +30,20 @@ class ProxyButtonGroup(ProxyToolkitObject):
 
 
 class ButtonGroup(ToolkitObject):
+    """ A way to declare a group of buttons.
+
+    This allows to group buttons even though they beloing to different
+    container.
+
+    """
+
+    #: Can only a single button in the group be checked at a time.
     exclusive = d_(Bool(True))
 
+    #: A reference to the ProxyButtonGroup object.
     proxy = Typed(ProxyButtonGroup)
 
     @observe("exclusive")
     def _update_proxy(self, change):
         super(ButtonGroup, self)._update_proxy(change)
 
-    def add_button(self, button):
-        if self.proxy_is_active:
-            self.proxy.add_button(button)
-
-    def remove_button(self, button):
-        if self.proxy_is_active:
-            self.proxy.remove_button(button)

--- a/enaml/widgets/button_group.py
+++ b/enaml/widgets/button_group.py
@@ -1,0 +1,36 @@
+from atom.api import Bool, ForwardTyped, Typed, observe
+
+from enaml.core.declarative import d_
+
+from .toolkit_object import ToolkitObject, ProxyToolkitObject
+
+
+class ProxyButtonGroup(ProxyToolkitObject):
+    declaration = ForwardTyped(lambda: ButtonGroup)
+
+    def set_exclusive(self, exclusive):
+        raise NotImplementedError
+
+    def add_button(self, button):
+        raise NotImplementedError
+
+    def remove_button(self, button):
+        raise NotImplementedError
+
+
+class ButtonGroup(ToolkitObject):
+    exclusive = d_(Bool(True))
+
+    proxy = Typed(ProxyButtonGroup)
+
+    @observe("exclusive")
+    def _update_proxy(self, change):
+        super(ButtonGroup, self)._update_proxy(change)
+
+    def add_button(self, button):
+        if self.proxy_is_active:
+            self.proxy.add_button(button)
+
+    def remove_button(self, button):
+        if self.proxy_is_active:
+            self.proxy.remove_button(button)

--- a/examples/widgets/button_group.enaml
+++ b/examples/widgets/button_group.enaml
@@ -1,3 +1,10 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2019, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
 """ An example of button groups in Enaml.
 
 This example shows the usage of the `ButtonGroup` widget in combination

--- a/examples/widgets/button_group.enaml
+++ b/examples/widgets/button_group.enaml
@@ -1,0 +1,56 @@
+""" An example of button groups in Enaml.
+
+This example shows the usage of the `ButtonGroup` widget in combination
+with multiple `RadioButton` widgets.
+
+The intent of this example is to show how several buttons in different
+containers can still be in the same group, ensuring that only one can
+be selected at any given time.
+
+This widget is currently only available for Qt.
+
+<< autodoc-me >>
+"""
+from enaml.widgets.api import (
+    Window, Container, HGroup, GroupBox, ButtonGroup, CheckBox, RadioButton
+)
+
+enamldef Main(Window):
+    title = "Button Group Example"
+    Container:
+        HGroup:
+            CheckBox:
+                text = "Group 1 Exclusive"
+                checked := btn_group1.exclusive
+            CheckBox:
+                text = "Group 2 Exclusive"
+                checked := btn_group2.exclusive
+        HGroup:
+            ButtonGroup: btn_group1:
+                pass
+            ButtonGroup: btn_group2:
+                pass
+            GroupBox:
+                title = "Group 1"
+                RadioButton:
+                    text = "Button Group 1"
+                    group = btn_group1
+                RadioButton:
+                    text = "Button Group 2"
+                    group = btn_group2
+            GroupBox:
+                title = "Group 2"
+                RadioButton:
+                    text = "Button Group 1"
+                    group = btn_group1
+                RadioButton:
+                    text = "Button Group 2"
+                    group = btn_group2
+            GroupBox:
+                title = "Group 3"
+                RadioButton:
+                    text = "Button Group 1"
+                    group = btn_group1
+                RadioButton:
+                    text = "Button Group 2"
+                    group = btn_group2

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -9,6 +9,7 @@ Enaml Release Notes
 -------------------
 - add a ButtonGroup widget and a group attribute on all buttons to allow to
   group buttons belonging to different containers. PR #346
+- fix an issue in ImageView when the image is None PR #361
 - add a sync_time attribute to Field to control teh refresh rate when using the
   'auto_sync' trigger mode. PR #353
 - multiple improvement of the documentation PR #341 #345 #350

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -5,6 +5,16 @@ Enaml Release Notes
 -------------------
 
 
+0.10.4 - unreleased
+-------------------
+- add a ButtonGroup widget and a group attribute on all buttons to allow to
+  group buttons belonging to different containers. PR #346
+- add a sync_time attribute to Field to control teh refresh rate when using the
+  'auto_sync' trigger mode. PR #353
+- multiple improvement of the documentation PR #341 #345 #350
+- add a new example about layout PR #343
+
+
 0.10.3 - 28/01/2019
 -------------------
 - implement import hooks using Python 3 interface #331

--- a/tests/widgets/test_button_group.py
+++ b/tests/widgets/test_button_group.py
@@ -1,0 +1,105 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2019, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+"""Test the button group widget.
+
+"""
+import pytest
+
+from utils import is_qt_available, compile_source, wait_for_window_displayed
+
+
+SOURCE ="""
+from enaml.widgets.api import RadioButton, ButtonGroup, Container, Window
+
+enamldef Main(Window):
+
+    alias rad1: rd1
+    alias rad2: rd2
+    alias rad3: rd3
+    alias rad4: rd4
+    alias rad5: rd5
+    alias rad6: rd6
+    alias group1: gr1
+    alias group2: gr2
+
+    ButtonGroup: gr1:
+        exclusive = True
+    ButtonGroup: gr2:
+        exclusive = False
+    Container:
+        Container:
+            RadioButton: rd1:
+                group = gr1
+                checked = True
+            RadioButton: rd2:
+                group = gr2
+                checked = True
+        Container:
+            RadioButton: rd3:
+                group = gr1
+            RadioButton: rd4:
+                group = gr2
+        Container:
+            RadioButton: rd5:
+                checked = False
+            RadioButton: rd6:
+                checked = False
+
+"""
+
+
+def test_tracking_group_members():
+    """Test that we track properly which buttons belongs to a group.
+
+    """
+    win = compile_source(SOURCE, 'Main')()
+    assert win.group1.group_members == set((win.rad1, win.rad3))
+    assert win.group2.group_members == set((win.rad2, win.rad4))
+
+    win.rad5.group = win.group1
+    assert win.group1.group_members == set((win.rad1, win.rad3, win.rad5))
+
+    win.rad5.group = win.group2
+    assert win.group1.group_members == set((win.rad1, win.rad3))
+    assert win.group2.group_members == set((win.rad2, win.rad4, win.rad5))
+
+    win.rad5.group = None
+    assert win.group2.group_members == set((win.rad2, win.rad4))
+
+
+@pytest.mark.skipif(not is_qt_available(), reason='Requires a Qt binding')
+def test_group_exclusivity(enaml_qtbot, enaml_sleep):
+    """Test that we properly enforce exclusivity within a group.
+
+    """
+    win = compile_source(SOURCE, 'Main')()
+    win.show()
+    wait_for_window_displayed(enaml_qtbot, win)
+
+    # Check that group 1 is exclusive
+    win.rad3.checked = True
+    enaml_qtbot.wait(enaml_sleep)
+    assert win.rad3.checked is True
+    assert win.rad1.checked is False
+
+    # Check that group 2 is non-exclusive
+    win.rad4.checked = True
+    enaml_qtbot.wait(enaml_sleep)
+    assert win.rad2.checked is True
+    assert win.rad4.checked is True
+
+    # Check that dynamically added members are part of the right group
+    win.rad5.group = win.group1
+    assert win.rad3.checked is True
+    assert win.rad1.checked is False
+    assert win.rad5.checked is False
+    win.rad5.checked = True
+    enaml_qtbot.wait(enaml_sleep)
+    assert win.rad3.checked is False
+    assert win.rad1.checked is False
+    assert win.rad5.checked is True


### PR DESCRIPTION
This is a proxy for Qt's QButtonGroup class, which allows manual
management of button groupings. This alleviates the restriction of
requiring all buttons to be within the same container to ensure that
only one button in the desired grouping can be selected at a time.

I don't think this is ready to merge in its current state. The
requirement to manually hook up the button to the button group in the
'activated' event handler is very clunky, but I'm not sure at present
of a better way of handling this.

I'm also not sure that it makes sense to have the button group as an
actual widget, but I wasn't sure of a better way to handle this either.
The Timer widget (a proxy for the QTimer class) appears to work in the
same way that this patch currently does.

I'm pretty sure there is some other documentation that needs updating,
such as anything that claims the only way to implement exclusitivity is
through a common container parent. I'd appreciate some guidance on this,
and on if any additional testing is required.


I also wanted to say thank you for such an amazing piece of work. I
found Enaml just three weeks ago, and it's been an absolute joy to work
with. I didn't think it was possible for desktop application development
to be so easy and fun. I know a large part of the software development
industry is moving towards the web, but there are absolutely still plenty
of important use cases where a desktop application makes more sense, so
it's very nice to see toolkits like this still being developed.