### PR TITLE
Fixing issue with validator fields

### DIFF
--- a/enaml/qt/qt_field.py
+++ b/enaml/qt/qt_field.py
@@ -126,7 +126,8 @@ class QtField(QtControl, ProxyField):
         # A temporary hack until styles are implemented
         if self._guard & ERROR_FLAG:
             self._guard &= ~ERROR_FLAG
-            self.widget.setStyleSheet(u'')
+            # Replace the widget's "error" stylesheet with the one defined in the declaration
+            self.refresh_style_sheet()
             self.widget.setToolTip(u'')
 
     def _maybe_valid(self, text):

--- a/enaml/qt/qt_field.py
+++ b/enaml/qt/qt_field.py
@@ -126,7 +126,8 @@ class QtField(QtControl, ProxyField):
         # A temporary hack until styles are implemented
         if self._guard & ERROR_FLAG:
             self._guard &= ~ERROR_FLAG
-            # Replace the widget's "error" stylesheet with the one defined in the declaration
+            # Replace the widget's "error" stylesheet with
+            # the one defined in the declaration
             self.refresh_style_sheet()
             self.widget.setToolTip(u'')
 

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -10,10 +10,12 @@ Enaml Release Notes
 - add a ButtonGroup widget and a group attribute on all buttons to allow to
   group buttons belonging to different containers. PR #346
 - fix an issue in ImageView when the image is None PR #361
-- add a sync_time attribute to Field to control teh refresh rate when using the
+- add a sync_time attribute to Field to control the refresh rate when using the
   'auto_sync' trigger mode. PR #353
 - multiple improvement of the documentation PR #341 #345 #350
 - add a new example about layout PR #343
+- fix issue where fields with a validator would lose their original stylesheet when
+  the error state of the validator is cleared. PR #365
 - fix Looper's ``loop_index`` becoming invalid when items are reordered #357 via PR #358
 
 .. note:: Looper's ``loop_index`` and ``loop_item`` scope variables are now deprecated. When upgrading to 0.10.4 or newer all usage of ``loop_index`` and ``loop_item`` within a Looper should be replaced with ``loop.index`` and ``loop.item`` respectively. See #357 for details.


### PR DESCRIPTION
Fixing issue with validator fields, where clearing the error state does not restore the original stylesheet