### PR TITLE
qt: fix q_dock_tab_widget for PyQt5

### DIFF
--- a/enaml/qt/docking/q_dock_tab_widget.py
+++ b/enaml/qt/docking/q_dock_tab_widget.py
@@ -191,7 +191,7 @@ class QDockTabBar(QTabBar):
         normal = QPixmap(opt.rect.size())
         normal.fill(Qt.transparent)
         painter = QStylePainter(normal, self)
-        painter.setFont(self.font())
+        self.initPainter(painter)
         painter.drawControl(QStyle.CE_TabBarTab, opt)
 
         # Snap the selected pixmap
@@ -199,7 +199,7 @@ class QDockTabBar(QTabBar):
         selected = QPixmap(opt.rect.size())
         selected.fill(Qt.transparent)
         painter = QStylePainter(selected, self)
-        painter.setFont(self.font())
+        self.initPainter(painter)
         painter.drawControl(QStyle.CE_TabBarTab, opt)
 
         # Reset the internal stylesheet style

--- a/enaml/qt/docking/q_dock_tab_widget.py
+++ b/enaml/qt/docking/q_dock_tab_widget.py
@@ -8,7 +8,7 @@
 from weakref import ref
 
 from enaml.qt import QT_API, PYQT5_API, PYSIDE2_API
-from enaml.qt.QtCore import Qt, QPoint, QSize, QMetaObject, QEvent
+from enaml.qt.QtCore import Qt, QPoint, QSize, QMetaObject, QEvent, QRect
 from enaml.qt.QtGui import (
     QMouseEvent, QResizeEvent, QCursor, QPainter, QPixmap
 )
@@ -191,7 +191,7 @@ class QDockTabBar(QTabBar):
         normal = QPixmap(opt.rect.size())
         normal.fill(Qt.transparent)
         painter = QStylePainter(normal, self)
-        painter.initFrom(self)
+        painter.setFont(self.font())
         painter.drawControl(QStyle.CE_TabBarTab, opt)
 
         # Snap the selected pixmap
@@ -199,7 +199,7 @@ class QDockTabBar(QTabBar):
         selected = QPixmap(opt.rect.size())
         selected.fill(Qt.transparent)
         painter = QStylePainter(selected, self)
-        painter.initFrom(self)
+        painter.setFont(self.font())
         painter.drawControl(QStyle.CE_TabBarTab, opt)
 
         # Reset the internal stylesheet style
@@ -358,6 +358,7 @@ class QDockTabBar(QTabBar):
             for index, data in enumerate(self._tab_data):
                 if data.alerted:
                     rect = self.tabRect(index)
+                    print("drawn on", rect)
                     pm = data.selected if index == current else data.normal
                     painter.drawPixmap(rect, pm)
 

--- a/enaml/widgets/dock_item.py
+++ b/enaml/widgets/dock_item.py
@@ -155,6 +155,5 @@ class DockItem(Widget):
         """ Called by the proxy when the toolkit item is closed.
 
         """
-        # TODO allow the user to veto the close request
         self.closed()
         deferred_call(self.destroy)

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,7 @@ Enaml Release Notes
 
 0.11.0 - unreleased
 -------------------
+- qt: fix alerts on tabbed DockItem PR #396
 - qt: avoid going higher than the dock area when looking for a DockTabWidget
   among the parents of a QDockContainer PR #386
 - properly report SyntaxError in f strings PR #378


### PR DESCRIPTION
initFrom was removed and we need to do its job manually. Still need to manually set the pen and background but it already seems to be working.

Closes #395