### PR TITLE
core: ensure that module attributes are properly set

### DIFF
--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -120,6 +120,8 @@ class AbstractEnamlImporter(object, metaclass=ABCMeta):
 
             spec = ModuleSpec(fullname, loader,
                               origin=loader.file_info.src_path)
+            spec.cached = loader.file_info.cache_path
+            spec.has_location = True
 
             return spec
 

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,7 @@ Enaml Release Notes
 
 0.11.0 - unreleased
 -------------------
+- properly set the attributes of imported of module PR #398
 - qt: avoid going higher than the dock area when looking for a DockTabWidget
   among the parents of a QDockContainer PR #386
 - properly report SyntaxError in f strings PR #378

--- a/tests/core/test_importer.py
+++ b/tests/core/test_importer.py
@@ -9,10 +9,12 @@ import importlib
 import os
 import sys
 import time
+from importlib.machinery import ModuleSpec
+
+from enaml.core.import_hooks import (AbstractEnamlImporter, EnamlImporter,
+                                     imports)
 
 import pytest
-
-from enaml.core.import_hooks import AbstractEnamlImporter, imports
 
 
 # Test handling wrong loader type
@@ -76,6 +78,14 @@ def test_import_and_cache_generation(enaml_module):
         importlib.import_module(name)
 
     assert name in sys.modules
+
+    # Check that the module attributes are properly populated
+    mod = sys.modules[name]
+    assert mod.__name__ == name
+    assert mod.__file__ == os.path.join(folder, name + ".enaml")
+    assert os.path.join(folder, "__enamlcache__") in mod.__cached__
+    assert isinstance(mod.__loader__, EnamlImporter)
+    assert isinstance(mod.__spec__, ModuleSpec)
 
     cache_folder = os.path.join(folder, '__enamlcache__')
     assert os.path.isdir(cache_folder)

--- a/tests/core/test_zipimporter.py
+++ b/tests/core/test_zipimporter.py
@@ -11,12 +11,13 @@ import enaml
 import struct
 import marshal
 import zipfile
+from importlib.machinery import ModuleSpec
 
 import pytest
 
 from enaml.core.parser import parse
 from enaml.core.enaml_compiler import EnamlCompiler
-from enaml.core.import_hooks import MAGIC_NUMBER, make_file_info
+from enaml.core.import_hooks import MAGIC_NUMBER, make_file_info, EnamlImporter
 from utils import wait_for_window_displayed, is_qt_available
 
 
@@ -115,6 +116,12 @@ def test_zipimport_from_module(enaml_qtbot, enaml_sleep, zip_library):
     with enaml.imports():
         # Test import from library.zip/buttons.enaml
         import buttons
+
+    assert buttons.__name__ == "buttons"
+    assert buttons.__file__
+    assert buttons.__cached__
+    assert isinstance(buttons.__loader__, EnamlImporter)
+    assert isinstance(buttons.__spec__, ModuleSpec)
 
     assert_window_displays(enaml_qtbot, enaml_sleep, buttons.Main())
 


### PR DESCRIPTION
The migration to Python 3 messed up the setting of the attributes on the module (\_\_file\_\_ in particular) this fixes it cleanly and add tests.