### PR TITLE
fixing bug in qt_widget.py/QtWidget.tab_focus_request().

### DIFF
--- a/enaml/qt/qt_widget.py
+++ b/enaml/qt/qt_widget.py
@@ -173,7 +173,7 @@ class QtWidget(QtToolkitObject, ProxyWidget):
 
         """
         widget = self.focus_target()
-        if not widget.focusPolicy & Qt.TabFocus:
+        if not widget.focusPolicy() & Qt.TabFocus:
             return False
         if not widget.isEnabled():
             return False


### PR DESCRIPTION
- widget.focusPolicy is a function/callable that is missing the round brackets.
- usable for alternative workaround for issue #401.