### PR TITLE
Declarative function reference counting issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
           fail_ci_if_error: true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -92,5 +91,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
           fail_ci_if_error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
   # Intall test tools (we require pytest > 3.3 to get the builtin logging
   # features)
   # Pytest-xvfb allows to run on CI (without a display with less magic)
-  - $PIP_INSTALL pytest pytest-cov pytest-qt pytest-xvfb
+  - $PIP_INSTALL pytest pytest-cov pytest-qt pytest-xvfb "pyvirtualdisplay<1.0"
 
   # Avoid annoying focus problems when running tests
   # See discussion in e.g. https://github.com/spyder-ide/spyder/pull/6132

--- a/enaml/src/declarative_function.cpp
+++ b/enaml/src/declarative_function.cpp
@@ -89,7 +89,7 @@ _Invoke( PyObject* func, PyObject* key, PyObject* self, PyObject* args,
     cppy::ptr f_globals( pfunc.getattr( "__globals__" ) );
     if( !f_globals )
         return cppy::attribute_error( pfunc.get(), "__globals__" );
-    cppy::ptr f_builtins( PyDict_GetItemString( f_globals.get(), "__builtins__" ) );
+    cppy::ptr f_builtins( cppy::xincref( PyDict_GetItemString( f_globals.get(), "__builtins__" ) ) );
     if( !f_builtins ){
         PyErr_Format(
             PyExc_KeyError,

--- a/enaml/version.py
+++ b/enaml/version.py
@@ -22,10 +22,10 @@ MINOR = 11
 
 # The micro release number. The micro release number is incremented
 # for bug fix releases and small feature additions.
-MICRO = 1
+MICRO = 2
 
 # The status indicate if this is a development or pre-release version
-STATUS = ''
+STATUS = 'dev'
 
 #: A namedtuple of the version info for the current release.
 version_info = namedtuple('version_info', 'major minor micro status')

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,11 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.11.2 - unreleased
+-------------------
+- fix reference counting in declarative function PR #417
+
+
 0.11.1 - 01/05/2020
 -------------------
 - fix signaling/weakmethod/callableref that were broken since 0.10.0 PR #416

--- a/tests/core/test_declarative_function.py
+++ b/tests/core/test_declarative_function.py
@@ -69,18 +69,21 @@ def test_declarative_function_get_and_call():
     tester = compile_source(source, 'MyWindow')()
     bdmethod = tester.call
     assert isinstance(bdmethod, BoundDeclarativeMethod)
-    assert bdmethod(1) is tester
-    assert bdmethod(arg=2) is tester
-    assert bdmethod(1, kwarg=1) is tester
+    for i in range(100):
+        assert bdmethod(1) is tester
+        assert bdmethod(arg=2) is tester
+        assert bdmethod(1, kwarg=1) is tester
     func = type(tester).call
     assert isinstance(func, DeclarativeFunction)
-    assert func(tester, 1) is tester
-    assert func(tester, arg=1) is tester
-    assert func(tester, arg=1, kwarg=2) is tester
+    for i in range(100):
+        assert func(tester, 1) is tester
+        assert func(tester, arg=1) is tester
+        assert func(tester, arg=1, kwarg=2) is tester
     func = type(tester).call2
     assert isinstance(func, DeclarativeFunction)
-    assert func(tester) is tester
-    assert func(tester) is tester
+    for i in range(100):
+        assert func(tester) is tester
+        assert func(tester) is tester
 
     with pytest.raises(TypeError) as excinfo:
         type(tester).call2()


### PR DESCRIPTION
This fixes a bug identified in https://github.com/nucleic/enaml/pull/348, which boils down to a reference counting issue in declarative function that led to the deletion of the builtins dictionary.