### PR TITLE
Add support for missing Python 3.8 features

### DIFF
--- a/docs/source/get_started/syntax.rst
+++ b/docs/source/get_started/syntax.rst
@@ -26,7 +26,7 @@ the `class` keyword in a normal Python file. Your widget must inherit from
 a widget, either a builtin one or one defined using an `enamldef` and cannot
 inherit from several widgets.
 
-In the body of the declaration, you add widget by simply declaring it. The 
+In the body of the declaration, you add widget by simply declaring it. The
 parent/child is directly encoded in the indentation. Furthermore, you can
 add to each widget an id which must unique inside the declaration. This id
 can be used to reference it in the layout (see :ref:`layout`), or to access
@@ -116,11 +116,14 @@ uses a set of four operators:
     but the type checking of the view property is enforced.
 
 `<<`
-    *Subscription*. Right hand side can be any expression. The expression will
-    be parsed for dependencies, and any dependency which is a member attribute
-    on a Atom class will have a listener attached. When the listener fires,
-    the expression will be re-evaluated and the value of the view property
+    *Subscription*. Right hand side can be any expression or statement.
+    In the case of an expression, the expression will be parsed for
+    dependencies, and any dependency which is a member attribute on a Atom
+    class will have a listener attached. When the listener fires, the
+    expression will be re-evaluated and the value of the view property
     will be updated.
+    The behavior for statements is quite similar. Whichever value the statement
+    return will be set to the left-hand side.
 
 `>>`
     *Update*. Right hand side must be a simple lvalue. The attribute will
@@ -131,21 +134,21 @@ uses a set of four operators:
     indented block of code can also be used. The statement/block will be
     evaluated any time the view property changes. Inside this block, one can
     access the notification that triggered the execution under the name
-    `change`. In  particular when using Atom object for the model, the new
-    value can be accessed as `change['value']`
+    ``change``. In  particular when using Atom object for the model, the new
+    value can be accessed as ``change['value']``
 
 
 Declarative function definition and overriding
 ----------------------------------------------
 
-In addition to defining attributes inside an `enamldef` declaration, one can 
+In addition to defining attributes inside an ``enamldef`` declaration, one can
 define the equivalent of methods, or override them. In the context of
-`enamldef` objects, we will refer to them as declarative functions.
+``enamldef`` objects, we will refer to them as declarative functions.
 
-Such functions are defined using the `func` keyword, and obey the scoping rules
-described in the next section. In particular, `self` can be used to access the
-instance of the widget on which they are defined but does not need to be listed
-explicitly in the arguments (and should not be).
+Such functions are defined using the ``func`` keyword, and obey the scoping
+rules described in the next section. In particular, ``self`` can be used to
+access the instance of the widget on which they are defined but does not need
+to be listed explicitly in the arguments (and should not be).
 
 Such functions can be overridden using a slightly different syntax, as
 illustrated below:
@@ -175,12 +178,77 @@ Scoping Rules
   includes all elements that have a declared identifier.
 - Each expression has its local namespace that is the union of the block
   locals and the attribute namespace of the object to which the expression
-  is bound. In other words, `self` is implicit. However, a `self` exists in
+  is bound. In other words, ``self`` is implicit. However, a ``self`` exists in
   this local namespace in order to break naming conflicts between block
   locals and attribute names. To any C++ or Java developers, this will seem
   natural.
 - Each expression has a dynamic scope which exists between its local scope
   and the global scope. This scope is the chained union of all attribute
-  namespaces of the ancestor tree of the object to which the expression
-  is bound.
+  namespaces of the ancestor tree of the object (i.e. the parents of the widget
+  on which teh expression is defined) to which the expression is bound.
 
+We illustrate these rules and of their consequences below:
+
+.. code-block:: enaml
+
+    enamldef MyWindow(Window):
+
+        attr a = 2
+
+        attr b: str = ""
+
+        a::
+            b = 1
+            self.b = "test"
+
+        b::
+            print(change)
+            print(f"{a}")
+
+In the example above, in the notification handler for ``a``, we first create a
+new local variable ``b``, which is scoped to the handler (i.e. it does not
+exist outside). In order to set the attribute ``b`` of the widget we need to
+use the implicit ``self`` referencing the widget. As a consequence, under
+Python 3.8, the walrus operator ``:=`` will always create a local variable and
+will never modify the state of the widget.
+
+In the notification handler of ``b``, we first access the implicit ``change``
+dictionary which is provided by the model. Second, we access the variable ``a``
+which does not exist in the local namespace and is hence found in the widget
+namespace. This is equivalent to ``self.a``.
+
+.. code-block:: enaml
+
+    enamldef MyLabel(Label):
+
+        text << f"{a}"
+
+    enamldef MyWindow(Window):
+
+        attr a = 2
+
+        MyLabel:
+            pass
+
+    enamldef MyWindow2(Window):
+
+        attr b = 2
+
+        MyLabel:
+            pass
+
+In the above example, ``MyWindow`` can be instantiated and the label text will
+be ``"2"``. It is because the parent of ``MyLabel`` i.e. ``MyWindow`` has the
+name ``a`` in its namespace. On the other end, ``MyWindow2`` will generate a
+:class:`NameError` since ``a`` is not defined in ``MyLabel`` scope nor in any
+of its parents scope.
+
+Using this feature requires to properly document the expectation of the widget
+since otherwise the reason for the :class:`NameError` may be hard to track. It
+is however a powerful feature to avoid manually propagating a name through the
+whole hierarchy. One typical example is when using the Enaml workbench with the
+UI plugin to build a plugin application. In such application, accessing the
+workbench object which is set on the main window is very common since the
+workbench orchestrate the interaction between plugins. Since it is set on the
+main window, any widget which can trace its ancestry to it, which is in the
+general the case for all widgets, can use the name ``workbench`` safely.

--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -12,8 +12,6 @@ import codecs
 import tokenize
 from types import CodeType
 
-USE_WORDCODE = sys.version_info >= (3, 6)
-
 PY38 = POS_ONLY_ARGS = sys.version_info >= (3, 8)
 
 

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -14,7 +14,7 @@ from types import CodeType
 import bytecode as bc
 from atom.api import Str, Typed
 
-from ..compat import USE_WORDCODE, PY38
+from ..compat import PY38
 from .code_generator import CodeGenerator
 from .enaml_ast import (
     AliasExpr, ASTVisitor, Binding, ChildDef, EnamlDef, StorageExpr, Template,
@@ -56,16 +56,13 @@ COMPILE_MODE = {
 
 #: Ast nodes associated with comprehensions which uses a function call that we
 #: will have to call in proper scope
-_FUNC_DEF_NODES = [ast.Lambda,
+_FUNC_DEF_NODES = (ast.Lambda,
                    ast.ListComp,
                    ast.DictComp,
-                   ast.SetComp]
-
-_FUNC_DEF_NODES = tuple(_FUNC_DEF_NODES)
+                   ast.SetComp)
 
 #: Opcode used to create a function
-_MAKE_FUNC = (("MAKE_FUNCTION",) +
-              (("MAKE_CLOSURE",) if not USE_WORDCODE else ()))
+_MAKE_FUNC = ("MAKE_FUNCTION",)
 
 
 def unhandled_pragma(name, filename, lineno):

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -7,7 +7,6 @@
 #------------------------------------------------------------------------------
 import sys
 
-from ..compat import USE_WORDCODE
 from . import compiler_common as cmn
 from .enaml_ast import Module
 from .enamldef_compiler import EnamlDefCompiler
@@ -253,8 +252,7 @@ class EnamlCompiler(cmn.CompilerBase):
             # Under Python 3.6+ default positional arguments are passed as a
             # single tuple and MAKE_FUNCTION is passed the flag 0x01 to
             # indicate that there is default positional arguments.
-            if USE_WORDCODE:
-                cg.build_tuple(len(node.parameters.keywords))
+            cg.build_tuple(len(node.parameters.keywords))
 
             # Generate the template code and function
             code = TemplateCompiler.compile(node, cg.filename)
@@ -263,8 +261,7 @@ class EnamlCompiler(cmn.CompilerBase):
             # Under Python 3 function have a qualified name
             # XXX improve qualified name
             cg.load_const(None)
-            cg.make_function(0x01 if USE_WORDCODE else
-                             len(node.parameters.keywords))
+            cg.make_function(0x01)
 
             # Load and call the helper which will build the template
             cmn.load_helper(cg, 'make_template', from_globals=True)

--- a/enaml/core/parser/base_parser.py
+++ b/enaml/core/parser/base_parser.py
@@ -1580,39 +1580,39 @@ class BaseEnamlParser(object):
         p[0] = [p[2]] + p[3]
 
     def p_testlist1(self, p):
-        ''' testlist : test '''
+        ''' testlist : namedexpr_test '''
         p[0] = p[1]
 
     def p_testlist2(self, p):
-        ''' testlist : test COMMA '''
+        ''' testlist : namedexpr_test COMMA '''
         p[0] = [p[1]]
 
     def p_testlist3(self, p):
-        ''' testlist : test testlist_list '''
+        ''' testlist : namedexpr_test testlist_list '''
         p[0] = [p[1]] + p[2]
 
     def p_testlist4(self, p):
-        ''' testlist : test testlist_list COMMA '''
+        ''' testlist : namedexpr_test testlist_list COMMA '''
         p[0] = [p[1]] + p[2]
 
     def p_testlist_list1(self, p):
-        ''' testlist_list : COMMA test '''
+        ''' testlist_list : COMMA namedexpr_test '''
         p[0] = [p[2]]
 
     def p_testlist_list2(self, p):
-        ''' testlist_list : testlist_list COMMA test '''
+        ''' testlist_list : testlist_list COMMA namedexpr_test '''
         p[0] = p[1] + [p[3]]
 
     # Star expr does not exist before Python 3 but to avoid redefining many
     # rules we take it into account here and add the star_expr rule only under
     # Python 3
     def p_test_or_star1(self, p):
-        ''' test_or_star : test '''
+        ''' test_or_star : namedexpr_test '''
         p[0] = p[1]
 
     # Under Python 3.5 star expr can occur in new places
     def p_test_or_star_new1(self, p):
-        ''' test_or_star_new : test '''
+        ''' test_or_star_new : namedexpr_test '''
         p[0] = p[1]
 
     def p_testlist_star_expr1(self, p):
@@ -1651,7 +1651,7 @@ class BaseEnamlParser(object):
         p[0] = p[1]
 
     def p_if_stmt1(self, p):
-        ''' if_stmt : IF test COLON suite '''
+        ''' if_stmt : IF namedexpr_test COLON suite '''
         if_stmt = ast.If()
         if_stmt.test = p[2]
         if_stmt.body = p[4]
@@ -1661,7 +1661,7 @@ class BaseEnamlParser(object):
         p[0] = if_stmt
 
     def p_if_stmt2(self, p):
-        ''' if_stmt : IF test COLON suite elif_stmts '''
+        ''' if_stmt : IF namedexpr_test COLON suite elif_stmts '''
         if_stmt = ast.If()
         if_stmt.test = p[2]
         if_stmt.body = p[4]
@@ -1671,7 +1671,7 @@ class BaseEnamlParser(object):
         p[0] = if_stmt
 
     def p_if_stmt3(self, p):
-        ''' if_stmt : IF test COLON suite else_stmt '''
+        ''' if_stmt : IF namedexpr_test COLON suite else_stmt '''
         if_stmt = ast.If()
         if_stmt.test = p[2]
         if_stmt.body = p[4]
@@ -1681,7 +1681,7 @@ class BaseEnamlParser(object):
         p[0] = if_stmt
 
     def p_if_stmt4(self, p):
-        ''' if_stmt : IF test COLON suite elif_stmts else_stmt '''
+        ''' if_stmt : IF namedexpr_test COLON suite elif_stmts else_stmt '''
         if_stmt = ast.If()
         if_stmt.test = p[2]
         if_stmt.body = p[4]
@@ -1706,7 +1706,7 @@ class BaseEnamlParser(object):
         p[0] = p[1]
 
     def p_elif_stmt(self, p):
-        ''' elif_stmt : ELIF test COLON suite '''
+        ''' elif_stmt : ELIF namedexpr_test COLON suite '''
         if_stmt = ast.If()
         if_stmt.test = p[2]
         if_stmt.body = p[4]
@@ -1720,7 +1720,7 @@ class BaseEnamlParser(object):
         p[0] = p[3]
 
     def p_while_stmt1(self, p):
-        ''' while_stmt : WHILE test COLON suite '''
+        ''' while_stmt : WHILE namedexpr_test COLON suite '''
         while_stmt = ast.While()
         while_stmt.test = p[2]
         while_stmt.body = p[4]
@@ -1730,7 +1730,7 @@ class BaseEnamlParser(object):
         p[0] = while_stmt
 
     def p_while_stmt2(self, p):
-        ''' while_stmt : WHILE test COLON suite ELSE COLON suite '''
+        ''' while_stmt : WHILE namedexpr_test COLON suite ELSE COLON suite '''
         while_stmt = ast.While()
         while_stmt.test = p[2]
         while_stmt.body = p[4]
@@ -2154,6 +2154,11 @@ class BaseEnamlParser(object):
     def p_dotted_name_list2(self, p):
         ''' dotted_name_list : dotted_name_list DOT NAME '''
         p[0] = p[1] + p[2] + p[3]
+
+    # Defined here to make the implementation of Py38 parser easier
+    def p_namedexpr_test1(self, p):
+        ''' namedexpr_test : test '''
+        p[0] = p[1]
 
     def p_test1(self, p):
         ''' test : or_test '''

--- a/enaml/core/parser/parser3.py
+++ b/enaml/core/parser/parser3.py
@@ -103,8 +103,8 @@ class Python3EnamlParser(BaseEnamlParser):
 
     def p_yield_expr3(self, p):
         ''' yield_expr : YIELD FROM testlist '''
-        value = ast_for_testlist(p[2])
-        p[0] = ast.Yield(value=value, lineno=p.lineno(1))
+        value = ast_for_testlist(p[3])
+        p[0] = ast.YieldFrom(value=value, lineno=p.lineno(1))
 
     def p_funcdef2(self, p):
         ''' funcdef : DEF NAME parameters RETURNARROW test COLON suite '''

--- a/enaml/core/parser/parser38.py
+++ b/enaml/core/parser/parser38.py
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 import ast
 
-from .base_parser import Store
+from .base_parser import Store, ast_for_testlist
 from .parser36 import Python36EnamlParser
 
 
@@ -39,6 +39,19 @@ class Python38EnamlParser(Python36EnamlParser):
                              defaults=defaults, vararg=vararg,
                              kwonlyargs=kwonlyargs, kw_defaults=kw_defaults,
                              kwarg=kwarg)
+
+    # Python 3.8 started alowing star expr in return and yield
+    def p_return_stmt2(self, p):
+        ''' return_stmt : RETURN testlist_star_expr '''
+        value = ast_for_testlist(p[2])
+        ret = ast.Return()
+        ret.value = value
+        p[0] = ret
+
+    def p_yield_expr2(self, p):
+        ''' yield_expr : YIELD testlist_star_expr '''
+        value = ast_for_testlist(p[2])
+        p[0] = ast.Yield(value=value, lineno=p.lineno(1))
 
     # This keyword argument needs to be asserted as a NAME, but using NAME
     # here causes ambiguity in the parse tables.

--- a/enaml/core/parser/parser38.py
+++ b/enaml/core/parser/parser38.py
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 import ast
 
-from .base_parser import Store, ast_for_testlist
+from .base_parser import FakeToken, Store, ast_for_testlist, syntax_error
 from .parser36 import Python36EnamlParser
 
 

--- a/enaml/core/standard_inverter.py
+++ b/enaml/core/standard_inverter.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013, Nucleic Development Team.
+# Copyright (c) 2013-2020, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -54,9 +54,8 @@ class StandardInverter(CodeInverter):
         See also: `CodeInverter.call_function`.
 
         """
-        nargs = argspec & 0xFF
-        nkwargs = (argspec >> 8) & 0xFF
-        if (func is getattr and (nargs == 2 or nargs == 3) and nkwargs == 0):
+        nargs = argspec
+        if (func is getattr and (nargs == 2 or nargs == 3)):
             obj, attr = argtuple[0], argtuple[1]
             setattr(obj, attr, value)
         else:

--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013, Nucleic Development Team.
+# Copyright (c) 2013-2020, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -121,7 +121,7 @@ class StandardTracer(CodeTracer):
                 obj.observe(d_name, observer)
 
     #--------------------------------------------------------------------------
-    # AbstractScopeListener Interface
+    # CodeTracer Interface
     #--------------------------------------------------------------------------
     def dynamic_load(self, obj, attr, value):
         """ Called when an object attribute is dynamically loaded.
@@ -133,9 +133,6 @@ class StandardTracer(CodeTracer):
         if isinstance(obj, Atom):
             self.trace_atom(obj, attr)
 
-    #--------------------------------------------------------------------------
-    # CodeTracer Interface
-    #--------------------------------------------------------------------------
     def load_attr(self, obj, attr):
         """ Called before the LOAD_ATTR opcode is executed.
 
@@ -153,9 +150,8 @@ class StandardTracer(CodeTracer):
         object is an Atom instance. See also: `CodeTracer.call_function`
 
         """
-        nargs = argspec & 0xFF
-        nkwargs = (argspec >> 8) & 0xFF
-        if (func is getattr and (nargs == 2 or nargs == 3) and nkwargs == 0):
+        nargs = argspec
+        if (func is getattr and (nargs == 2 or nargs == 3)):
             obj, attr = argtuple[0], argtuple[1]
             if isinstance(obj, Atom) and isinstance(attr, str):
                 self.trace_atom(obj, attr)

--- a/examples/widgets/image_view.enaml
+++ b/examples/widgets/image_view.enaml
@@ -12,6 +12,7 @@ This example shows how a PNG image (in an enaml Image object) can displayed.
 << autodoc-me >>
 """
 import os
+from pathlib import Path
 
 from enaml.image import Image
 from enaml.layout.api import vbox, hbox, spacer
@@ -25,9 +26,9 @@ def image_path(name):
 
 IMAGES = {
     'None': None,
-    'Image A': Image(data=open(image_path('img1.png'), 'rb').read()),
-    'Image B': Image(data=open(image_path('img2.png'), 'rb').read()),
-    'Image C': Image(data=open(image_path('img3.png'), 'rb').read()),
+    'Image A': Image(data=Path(image_path('img1.png')).read_bytes()),
+    'Image B': Image(data=Path(image_path('img2.png')).read_bytes()),
+    'Image C': Image(data=Path(image_path('img3.png')).read_bytes()),
 }
 
 

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,16 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.12.0 - unreleased
+-------------------
+- add support for subscription block PR #348
+  Subscription blocks allow to write right to left synchronization logic over
+  multiple lines and using statements. The assigned value is the value returned
+  from the block.
+- add support for Python 3.8 only syntax PR #348
+  This covers: the walrus operator (:=), and the use of * in return and yields
+
+
 0.11.2 - 03/06/2020
 -------------------
 - fix reference counting in declarative function PR #417

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -9,7 +9,7 @@ Dates are written as DD/MM/YYYY
   Subscription blocks allow to write right to left synchronization logic over
   multiple lines and using statements. The assigned value is the value returned
   from the block.
-- add support for Python 3.8 only syntax PR #348
+- add support for Python 3.8 only syntax PR #422
   This covers: the walrus operator (:=), and the use of * in return and yields
 
 

--- a/tests/core/parser/test_return.py
+++ b/tests/core/parser/test_return.py
@@ -1,0 +1,52 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2020, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#------------------------------------------------------------------------------
+import sys
+import ast
+from textwrap import dedent
+
+import pytest
+
+from enaml.core.parser import parse
+
+from .test_parser import validate_ast
+
+TEST_SOURCE = {
+    'return': r"""
+    def f():
+        return
+    """,
+    'return a': r"""
+    def f():
+        return a
+    """,
+    'return a, (b, c)': r"""
+    def f():
+        return a, (b, c)
+    """,
+}
+
+TEST_SOURCE_38 = {
+    'return a, *b': r"""
+    def f():
+        return a, *b
+    """
+}
+
+@pytest.mark.parametrize('desc',
+    list(TEST_SOURCE) + list(TEST_SOURCE_38) if sys.version_info >= (3, 8) else []
+)
+def test_return_stmt(desc):
+    """Test that we produce valid ast use of the := walrus operator.
+
+    """
+    src = dedent(TEST_SOURCE.get(desc, TEST_SOURCE_38.get(desc))).strip()
+    print(src)
+    # Ensure it's valid
+    py_ast = ast.parse(src)
+    enaml_ast = parse(src).body[0].ast
+    validate_ast(py_ast.body[0], enaml_ast.body[0], True)

--- a/tests/core/parser/test_walrus.py
+++ b/tests/core/parser/test_walrus.py
@@ -58,3 +58,25 @@ def test_walrus_operator(desc):
     py_ast = ast.parse(src)
     enaml_ast = parse(src).body[0].ast
     validate_ast(py_ast.body[0], enaml_ast.body[0], True)
+
+
+TEST_BAD_SOURCE = {
+    ':= in while': r"""
+    while 2 := 1:
+        pass
+    """,
+    ':= in function argument': r"""
+    f(a, 2 := c or None)
+    """
+}
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='Requires Python 3.8')
+@pytest.mark.parametrize('desc', TEST_BAD_SOURCE.keys())
+def test_invalid_walrus_operator(desc):
+    """Test that we produce valid ast use of the := walrus operator.
+
+    """
+    src = dedent(TEST_BAD_SOURCE[desc]).strip()
+    print(src)
+    with pytest.raises(SyntaxError):
+        enaml_ast = parse(src).body[0].ast

--- a/tests/core/parser/test_walrus.py
+++ b/tests/core/parser/test_walrus.py
@@ -1,0 +1,60 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2020, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#------------------------------------------------------------------------------
+import sys
+import ast
+from textwrap import dedent
+
+import pytest
+
+from enaml.core.parser import parse
+
+from .test_parser import validate_ast
+
+TEST_SOURCE = {
+    ':= in expr': r"""
+    a = (b := 1)
+    """,
+    ':= in tuple': r"""
+    a = (2, b := 1)
+    """,
+    ':= in list': r"""
+    a = [2, b := 1]
+    """,
+    ':= in if': r"""
+    if b := 1:
+        pass
+    """,
+    ':= in elif': r"""
+    a = 0
+    if a:
+        pass
+    elif b := 1:
+        pass
+    """,
+    ':= in while': r"""
+    while b := 1:
+        pass
+    """,
+    ':= in function argument': r"""
+    f(a, b := c or None)
+    """
+}
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='Requires Python 3.8')
+@pytest.mark.parametrize('desc', TEST_SOURCE.keys())
+def test_walrus_operator(desc):
+    """Test that we produce valid ast use of the := walrus operator.
+
+    """
+    src = dedent(TEST_SOURCE[desc]).strip()
+    print(src)
+    # Ensure it's valid
+    py_ast = ast.parse(src)
+    enaml_ast = parse(src).body[0].ast
+    validate_ast(py_ast.body[0], enaml_ast.body[0], True)

--- a/tests/core/parser/test_yield.py
+++ b/tests/core/parser/test_yield.py
@@ -1,0 +1,56 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2020, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#------------------------------------------------------------------------------
+import sys
+import ast
+from textwrap import dedent
+
+import pytest
+
+from enaml.core.parser import parse
+
+from .test_parser import validate_ast
+
+TEST_SOURCE = {
+    'yield': r"""
+    def f():
+        yield
+    """,
+    'yield a': r"""
+    def f():
+        yield a
+    """,
+    'yield a, (b, c)': r"""
+    def f():
+        yield a, (b, c)
+    """,
+    'yield from a': r"""
+    def f():
+        yield from a
+    """
+}
+
+TEST_SOURCE_38 = {
+    'yield a, *b': r"""
+    def f():
+        yield a, *b
+    """
+}
+
+@pytest.mark.parametrize('desc',
+    list(TEST_SOURCE) + list(TEST_SOURCE_38) if sys.version_info >= (3, 8) else []
+)
+def test_return_stmt(desc):
+    """Test that we produce valid ast use of the := walrus operator.
+
+    """
+    src = dedent(TEST_SOURCE.get(desc, TEST_SOURCE_38.get(desc))).strip()
+    print(src)
+    # Ensure it's valid
+    py_ast = ast.parse(src)
+    enaml_ast = parse(src).body[0].ast
+    validate_ast(py_ast.body[0], enaml_ast.body[0], True)

--- a/tests/core/test_operators.py
+++ b/tests/core/test_operators.py
@@ -5,6 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
+import sys
 from textwrap import dedent
 
 import pytest
@@ -300,3 +301,32 @@ def test_subscription_block_observers5():
     window.a = 1
     assert label.text == 'a'
     assert window.counter == 4
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Require Python 3.8+")
+def test_subscription_operator_walrus():
+    """Test handling the walrus operator inside a subscription.
+
+    """
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        alias label
+        alias label2
+        attr a = 1
+        attr b = 2
+        attr c = 5
+        Label: label:
+            text << f"{a + (c := b + 1)}"
+        Label: label2:
+            text << f"{c}"
+
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    label = window.label
+    assert label.text == '4'
+    # This is the same behavior as everywhere else where access can use a bare name
+    # but assignment needs a qualified name.
+    assert window.label2.text == '5'

--- a/tests/core/test_operators.py
+++ b/tests/core/test_operators.py
@@ -121,6 +121,13 @@ def test_subscription_block_syntax(name):
         Main = compile_source(source, 'Main')
         window = Main()
 
+# The following tests need to ensure that assignment in subscription block
+# (either through a direct assignment or through the use of the walrus
+# operator) do not cause issue with the tracer.
+# Assignments can target the following scopes:
+# - local to the block (only scope that the walrus operator target)
+# - global module scope
+# - widget and dynamic scope that can only be accessed qualified names (self.)
 
 def test_subscription_block_observers1():
     """Test a subscription block operator.
@@ -155,7 +162,7 @@ def test_subscription_block_observers1():
 
 
 def test_subscription_block_observers2():
-    """Test that intermediate assignments do not confuse the tracer.
+    """Test that intermediate assignments (local) do not confuse the tracer.
 
     """
     source = dedent("""\


### PR DESCRIPTION
This covers the walrus operator := and the use of * in return and yield