### PR TITLE
Allow to explicitly set Qt application name

### DIFF
--- a/enaml/qt/qt_application.py
+++ b/enaml/qt/qt_application.py
@@ -29,6 +29,12 @@ class QtApplication(Application):
 
     def __init__(self,  appname=None):
         """ Initialize a QtApplication.
+        
+        Parameters
+        ----------
+        appname : str, optional
+            Explicit application name to use for setting the WM_CLASS attribute 
+            on Linux.
 
         """
         super(QtApplication, self).__init__()

--- a/enaml/qt/qt_application.py
+++ b/enaml/qt/qt_application.py
@@ -27,12 +27,16 @@ class QtApplication(Application):
     #: The private QApplication instance.
     _qapp = Typed(QApplication)
 
-    def __init__(self):
+    def __init__(self,  appname=None):
         """ Initialize a QtApplication.
 
         """
         super(QtApplication, self).__init__()
-        self._qapp = QApplication.instance() or QApplication([])
+        if appname is not None:
+            self._qapp = QApplication.instance() or QApplication([appname])
+        else:
+            self._qapp = QApplication.instance() or QApplication([])
+            
         self.resolver = ProxyResolver(factories=QT_FACTORIES)
 
     #--------------------------------------------------------------------------

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,11 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.13.0 - 03/12/2020
+-------------------
+- add support for explicit Qt app name PR #430
+  Allows setting the WM_CLASS property for X11 (Linux) apps.
+
 0.12.0 - 04/11/2020
 -------------------
 - add support for Python 3.9 PR #424

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,7 +3,7 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
-0.13.0 - 03/12/2020
+0.13.0 - unreleased
 -------------------
 - add support for explicit Qt app name PR #430
   Allows setting the WM_CLASS property for X11 (Linux) apps.


### PR DESCRIPTION
The argument to QApplication is used to set the application name. On Linux (Xorg) this can be queried using the xprop utility. Specifically, this name will be used for the ``WM_CLASS`` property [1], which can be used by X-based window managers to manipulate window placement and app-specific behaviour (automatic floating, tiling, positioning, etc). The approach proposed here is used by Jupyter's QtConsole [2] for example.

[1] https://tronche.com/gui/x/icccm/sec-4.html#WM_CLASS
[2] jupyter/qtconsole#16

This is only for the Qt backend.. I'm not familiar with the other frameworks.

- [x] Modify enaml.qt.qt_application.QtApplication
- [x] Update releasenotes.rst
- [ ] Add test case 