### PR TITLE
setup: add extras_require to allow to easily install Qt

### DIFF
--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -35,7 +35,8 @@ Python
 ~~~~~~
 
 Enaml is a Python framework and requires a supported Python runtime. Enaml
-currently supports **Python 3.6**, **Python 3.7** and **Python 3.8**.
+currently supports **Python 3.6**, **Python 3.7**, **Python 3.8** and
+**Python 3.9**.
 
 The most recent Python releases are available on the `Python Downloads`_ pages.
 Installers are available for Windows and OSX. Linux users should install Python
@@ -66,10 +67,18 @@ Qt 5 toolkit.  (It includes the necessary parts of Qt 5.)
 On 32 and 64-bit Windows, 64-bit OS X and 64-bit Linux, with Python
 versions >=3.6, it can be installed via pip::
 
-    $ pip install pyqt5
+    $ pip install qtpy pyqt5
 
 .. note::
     There is no pyqt5 wheel available for 32-bit Linux.
+
+.. note::
+    On Enaml >= 0.13 you can specify a rendering library using extra_requires, ie::
+
+    $ pip install enaml[qt5-pyqt]
+
+    Currently, you can use either [qt5-pyqt] or [qt5-pyside] to use either PyQt5
+    or Pyside2.
 
 Alternatives
 ++++++++++++

--- a/enaml/version.py
+++ b/enaml/version.py
@@ -18,14 +18,14 @@ MAJOR = 0
 # possibly small differences in the API, but these changes will come
 # backwards compatibility support when possible. Minor releases are
 # typically used for large feature additions.
-MINOR = 12
+MINOR = 13
 
 # The micro release number. The micro release number is incremented
 # for bug fix releases and small feature additions.
 MICRO = 0
 
 # The status indicate if this is a development or pre-release version
-STATUS = ''
+STATUS = 'dev'
 
 #: A namedtuple of the version info for the current release.
 version_info = namedtuple('version_info', 'major minor micro status')

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -5,6 +5,8 @@ Dates are written as DD/MM/YYYY
 
 0.13.0 - unreleased
 -------------------
+- add extra_requires to provide an easy way to install qt bindings
+  when relevant PR # 434
 - add support for explicit Qt app name PR #430
   Allows setting the WM_CLASS property for X11 (Linux) apps.
 

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: Implementation :: CPython',
       ],
     python_requires='>=3.6',
@@ -178,6 +179,10 @@ setup(
                       "bytecode>=0.11.0"
                       ],
     setup_requires=['cppy>=1.1.0'],
+    extras_require={
+        "qt5-pyqt": ["qtpy", "pyqt5"],
+        "qt5-pyside": ["qtpy", "pyside2"]
+    },
     packages=find_packages(),
     package_data={
         'enaml.applib': ['*.enaml'],


### PR DESCRIPTION
This allows to avoid polluting the enaml install while still providing a nice way to access the qt backend.