### PR TITLE
Minor fixes to vim syntax highlighting

### DIFF
--- a/tools/vim/syntax/enaml.vim
+++ b/tools/vim/syntax/enaml.vim
@@ -22,9 +22,10 @@ endif
 
 " Enaml extensions
 syn keyword enamlStatement      enamldef
+syn match enamlAttribute        "\%(\s*\)\zs\(attr\)\ze\%(\s\w\)"
 " FIXME: This captures the predefined operators, not any extensions that may be
 " added.
-syn match enamlOperator         "\%(\w\|\s\)\(::\|<<\|>>\|=\|:=\)\%(\w\|\s\)"
+syn match enamlOperator         "\%(\w\|\s\)\zs\(::\|<<\|>>\|=\|:=\)\ze\%(\w\|\s\|$\)"
 if exists("python_highlight_builtins") || exists("enaml_highlight_builtins")
     syn keyword enamlBuiltin    horizontal vertical hbox vbox align spacer
 endif
@@ -39,6 +40,7 @@ if version >= 508 || !exists("did_enaml_syntax_inits")
   endif
   HiLink enamlStatement         Statement
   HiLink enamlOperator          Operator
+  HiLink enamlAttribute         Define
   if exists("python_highlight_builtins") || exists("enaml_highlight_builtins")
       HiLink enamlBuiltin       Function
   endif

--- a/tools/vim/syntax/enaml.vim
+++ b/tools/vim/syntax/enaml.vim
@@ -21,7 +21,7 @@ else
 endif
 
 " Enaml extensions
-syn keyword enamlStatement      enamldef attr func
+syn keyword enamlStatement      enamldef attr func alias
 " FIXME: This captures the predefined operators, not any extensions that may be
 " added.
 syn match enamlOperator         "\%(\w\|\s\)\zs\(::\|<<\|>>\|=\|:=\)\ze\%(\w\|\s\|$\)"

--- a/tools/vim/syntax/enaml.vim
+++ b/tools/vim/syntax/enaml.vim
@@ -21,8 +21,7 @@ else
 endif
 
 " Enaml extensions
-syn keyword enamlStatement      enamldef
-syn match enamlAttribute        "\%(\s*\)\zs\(attr\)\ze\%(\s\w\)"
+syn keyword enamlStatement      enamldef attr func
 " FIXME: This captures the predefined operators, not any extensions that may be
 " added.
 syn match enamlOperator         "\%(\w\|\s\)\zs\(::\|<<\|>>\|=\|:=\)\ze\%(\w\|\s\|$\)"
@@ -40,7 +39,6 @@ if version >= 508 || !exists("did_enaml_syntax_inits")
   endif
   HiLink enamlStatement         Statement
   HiLink enamlOperator          Operator
-  HiLink enamlAttribute         Define
   if exists("python_highlight_builtins") || exists("enaml_highlight_builtins")
       HiLink enamlBuiltin       Function
   endif


### PR DESCRIPTION
This fixes spurrious highlighting of characters immediately preceding
or following an enamlOperator. Also, the case of the notification
operator `::` followed by and EOL is now handled correctly. Lastly, the
`attr` keyword is highlighted using the Define group (like python
decorators, etc.)