### PR TITLE
examples: prevent crash if executing a handler in the editor raises

### DIFF
--- a/examples/applib/live_editor.enaml
+++ b/examples/applib/live_editor.enaml
@@ -12,6 +12,9 @@ stitched together to form a live Enaml code editor application.
 
 << autodoc-me >>
 """
+import sys
+import traceback
+
 from enaml.applib.live_editor_model import LiveEditorModel
 from enaml.applib.live_editor_view import (
     ModelEditorPanel, ViewEditorPanel, TracebackPanel, ViewPanel
@@ -52,6 +55,14 @@ enamldef Main(Window):
         view_item='DemoContainer',
         view_filename='demo.enaml',
     )
+
+    func handle_uncaught_exception(exc, value, tb):
+        """Send uncaught exception to the model to avoid crashing the editor."""
+        editor_model.traceback = "".join(traceback.format_exception(exc, value, tb))
+
+    initialized::
+        sys.excepthook = handle_uncaught_exception
+
     Container:
         padding = 0
         DockArea:

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -5,6 +5,7 @@ Dates are written as DD/MM/YYYY
 
 0.13.0 - unreleased
 -------------------
+- make app editor more resilient to errors PR #440
 - fixes to vim synatx highlighting PR #439
 - fix documentation of ScrollArea example PR #438
 - add extra_requires to provide an easy way to install qt bindings


### PR DESCRIPTION
Closes #436

Any error occurring will be redirected to the error pane, and the editor remain live. 

Note that the same approach should not be used in a general app since raising in a handler can leave the app in a corrupted state.