### PR TITLE
Fix template instance operator binding.

### DIFF
--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,10 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.14.0 - unreleased
+-------------------
+- fix operator bindings in template instances PR #445
+
 0.13.0 - 19/04/2021
 -------------------
 - fix Python 3.9 only syntax issue PR #443

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def enaml_sleep():
     return DIALOG_SLEEP
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def qt_app():
     """Make sure a QtApplication is active.
 
@@ -76,7 +76,7 @@ def qt_app():
         yield app
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def enaml_qtbot(qt_app, qtbot):
     qtbot.enaml_app = qt_app
     with close_all_windows(qtbot), close_all_popups(qtbot):

--- a/tests/test_inner_functions.py
+++ b/tests/test_inner_functions.py
@@ -13,7 +13,8 @@ import pytest
 
 from utils import compile_source
 
-OPERATOR_TEMPLATE =\
+
+OPERATOR_TEMPLATES = [
 """from enaml.widgets.window import Window
 
 enamldef Main(Window):
@@ -30,10 +31,37 @@ enamldef Main(Window):
             raise AssertionError('i leaked out of the comprehension')
         self.called = True
 
+""",
+"""from enaml.widgets.window import Window, Container
+
+template Temp():
+
+    Container:
+        event ev
+        attr called : bool = False
+
+enamldef Main(Window):
+
+    alias ev: t.ev
+    alias called: t.called
+
+    Temp(): t:
+        t.ev ::
+            test = 1
+            a = {}
+            try:
+                b = i
+            except NameError:
+                pass
+            else:
+                raise AssertionError('i leaked out of the comprehension')
+            t.called = True
+
 """
+]
 
 
-SYNCHRONISATION_TEMPLATE =\
+SYNCHRONIZATION_TEMPLATES = [
 """from enaml.widgets.api import Window, Container, Field, Label
 
 enamldef Main(Window):
@@ -49,10 +77,36 @@ enamldef Main(Window):
         Label: lab:
             text << '{{}}'.format({})
 
+""",
+"""from enaml.widgets.api import Window, Container, Field, Label
+
+template Temp():
+
+    Container: container:
+
+        alias fd: search.text
+        alias lb: lab.text
+
+        Field: search:
+            placeholder = "Search..."
+        Label: lab:
+            text << '{{}}'.format({})
+
+
+enamldef Main(Window):
+
+    attr colors = ['red', 'blue', 'yellow', 'green']
+    alias search_txt : t.fd
+    alias formatted_comp : t.lb
+
+    Temp(): t:
+        pass
+
 """
+]
 
 
-FUNCTION_TEMPLATE =\
+FUNCTION_TEMPLATES =[
 """from enaml.widgets.window import Window
 
 enamldef Main(Window):
@@ -67,24 +121,52 @@ enamldef Main(Window):
             raise AssertionError('i leaked out of the comprehension')
         return True
 
+""",
+"""from enaml.widgets.window import Window, Container
+
+template Temp():
+
+    Container:
+        func call():
+            test = 1
+            a = {}
+            try:
+                b = i
+            except NameError:
+                pass
+            else:
+                raise AssertionError('i leaked out of the comprehension')
+            return True
+
+enamldef Main(Window):
+
+    func call():
+        return t.call()
+
+    Temp(): t:
+        pass
+
 """
+]
 
 
-def test_lambda():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_lambda(template):
     """Test that lambda work when used in the context of tracing.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         'sorted([1, 2, 3], key=lambda x: -x)')
     win = compile_source(source, 'Main')()
     assert win.formatted_comp == '[3, 2, 1]'
 
 
-def test_tracing_lambda():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_tracing_lambda(template):
     """Test that lambda can be traced.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         'sorted([1, 2, 3], key=lambda x: colors[x-1][0])')
     win = compile_source(source, 'Main')()
     assert win.formatted_comp == '[2, 1, 3]'
@@ -93,22 +175,24 @@ def test_tracing_lambda():
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", OPERATOR_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_list_comprehension_operator(value):
+def test_list_comprehension_operator(template, value):
     """Test running a list comprehension in an operator handler.
 
     """
-    source = OPERATOR_TEMPLATE.format('[%s for i in range(10)]' % value)
+    source = template.format('[%s for i in range(10)]' % value)
     win = compile_source(source, 'Main')()
     win.ev = True
     assert win.called
 
 
-def test_list_comprehension_synchronization():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_list_comprehension_synchronization(template):
     """Test running a list comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         '[c for c in colors if not search.text or search.text in c]')
     win = compile_source(source, 'Main')()
     assert win.formatted_comp == "['red', 'blue', 'yellow', 'green']"
@@ -120,33 +204,36 @@ def test_list_comprehension_synchronization():
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", FUNCTION_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_list_comprehension_func(value):
+def test_list_comprehension_func(template, value):
     """Test running a list comprehension in a declarative function.
 
     """
-    source = FUNCTION_TEMPLATE.format('[%s for i in range(10)]' % value)
+    source = template.format('[%s for i in range(10)]' % value)
     win = compile_source(source, 'Main')()
     assert win.call()
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", OPERATOR_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_dict_comprehension_operator(value):
+def test_dict_comprehension_operator(template, value):
     """Test running a dict comprehension in an operator handler.
 
     """
-    source = OPERATOR_TEMPLATE.format('{i: %s for i in range(10)}' % value)
+    source = template.format('{i: %s for i in range(10)}' % value)
     win = compile_source(source, 'Main')()
     win.ev = True
     assert win.called
 
 
-def test_dict_comprehension_synchronisation():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_dict_comprehension_synchronisation(template):
     """Test running a dict comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         '{i: search.text for i in range(3)}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {0: '', 1: '', 2: ''}
@@ -155,33 +242,36 @@ def test_dict_comprehension_synchronisation():
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", FUNCTION_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_dict_comprehension_func(value):
+def test_dict_comprehension_func(template, value):
     """Test running a dict comprehension in a declarative function.
 
     """
-    source = FUNCTION_TEMPLATE.format('{i: %s for i in range(10)}' % value)
+    source = template.format('{i: %s for i in range(10)}' % value)
     win = compile_source(source, 'Main')()
     assert win.call()
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", OPERATOR_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_set_comprehension_operator(value):
+def test_set_comprehension_operator(template, value):
     """Test running a set comprehension in an operator handler.
 
     """
-    source = OPERATOR_TEMPLATE.format('{%s for i in range(10)}' % value)
+    source = template.format('{%s for i in range(10)}' % value)
     win = compile_source(source, 'Main')()
     win.ev = True
     assert win.called
 
 
-def test_set_comprehension_synchronization():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_set_comprehension_synchronization(template):
     """Test running a set comprehension in a traced read handler.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         '{search.text for i in range(3)}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {''}
@@ -190,30 +280,33 @@ def test_set_comprehension_synchronization():
 
 
 # Test that we can access the non local values and the closure variables
+@pytest.mark.parametrize("template", FUNCTION_TEMPLATES)
 @pytest.mark.parametrize('value', ['self', 'test'])
-def test_set_comprehension_func(value):
+def test_set_comprehension_func(template, value):
     """Test running a set comprehension in a declarative function.
 
     """
-    source = FUNCTION_TEMPLATE.format('{%s for i in range(10)}' % value)
+    source = template.format('{%s for i in range(10)}' % value)
     win = compile_source(source, 'Main')()
     assert win.call()
 
 
-def test_handling_nested_comprehension():
+@pytest.mark.parametrize("template", FUNCTION_TEMPLATES)
+def test_handling_nested_comprehension(template):
     """Test handling nested comprehensions.
 
     """
-    source = FUNCTION_TEMPLATE.format('{self for i in {j for j in range(10)}}')
+    source = template.format('{self for i in {j for j in range(10)}}')
     win = compile_source(source, 'Main')()
     assert win.call()
 
 
-def test_handling_nested_comprehension_synchronization():
+@pytest.mark.parametrize("template", SYNCHRONIZATION_TEMPLATES)
+def test_handling_nested_comprehension_synchronization(template):
     """Test handling nested comprehensions in a traced read.
 
     """
-    source = SYNCHRONISATION_TEMPLATE.format(
+    source = template.format(
         '{search.text for i in {j for j in colors}}')
     win = compile_source(source, 'Main')()
     assert eval(win.formatted_comp) == {''}


### PR DESCRIPTION
Template instance operator binding require some extra work compared to conventional operator binding since we need both the node where the template is instantiated and where it is defined. However the analysis of globals and comprehensions performed for standards operators apply but was not carried out previously. This bug has been there for quite some time and was likely introduced when migrating to Python 3.

This needs tests before it can be merged.