### PR TITLE
Flow Layout sort fix for stretch or ortho_stretch > 0

### DIFF
--- a/enaml/qt/q_flow_layout.py
+++ b/enaml/qt/q_flow_layout.py
@@ -357,7 +357,7 @@ class _LayoutRow(object):
                     h = item.sizeHint().width()
                     m = item.maximumSize().width()
                     diffs.append((m - h, item))
-            diffs.sort()
+            diffs.sort(key=lambda i: i[0])
             for ignored, item in diffs:
                 item_stretch = item.data.stretch
                 max_width = item.maximumSize().width()
@@ -573,7 +573,7 @@ class _LayoutColumn(object):
                     h = item.sizeHint().height()
                     m = item.maximumSize().height()
                     diffs.append((m - h, item))
-            diffs.sort()
+            diffs.sort(key=lambda i: i[0])
             for ignored, item in diffs:
                 item_stretch = item.data.stretch
                 max_height = item.maximumSize().height()

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -6,6 +6,7 @@ Dates are written as DD/MM/YYYY
 0.14.0 - unreleased
 -------------------
 - fix operator bindings in template instances PR #445
+- fix FlowLayout error with FlowItems that have non-zero stretch or ortho_stretch PR #448
 
 0.13.0 - 19/04/2021
 -------------------

--- a/tests/test_flow_layout.py
+++ b/tests/test_flow_layout.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Copyright (c) 2013-2017, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ------------------------------------------------------------------------------
+
+import pytest
+
+from utils import is_qt_available
+
+pytestmark = pytest.mark.skipif(not is_qt_available(),
+                                reason='Requires a Qt binding')
+
+from utils import compile_source, wait_for_window_displayed
+
+FLOW_EXAMPLE = \
+"""from enaml.widgets.api import Window, Container, FlowItem, FlowArea
+from enaml.core.api import Include
+
+enamldef SomeFlowItem(FlowItem):
+    stretch = 1
+    ortho_stretch = 1
+
+
+enamldef Main(Window):
+    Container:
+        FlowArea:
+            Include:
+               objects << [SomeFlowItem() for _ in range(4)]
+
+"""
+
+
+def test_flow_layout_sort_with_non_zero_item_stretch(enaml_qtbot, enaml_sleep):
+    """Test that a FlowArea that contains FlowItems with non zero ortho_stretch or stretch
+    doesnt error with:
+
+    TypeError: '<' not supported between instances of 'QFlowWidgetItem' and 'QFlowWidgetItem'
+    """
+    win = compile_source(FLOW_EXAMPLE, 'Main')()
+    win.show()
+    wait_for_window_displayed(enaml_qtbot, win)
+    enaml_qtbot.wait(enaml_sleep)


### PR DESCRIPTION
Potential fix for issue mentioned in https://github.com/nucleic/enaml/issues/447

```
<class 'TypeError'>
'<' not supported between instances of 'QFlowWidgetItem' and 'QFlowWidgetItem'

```

Dont rely on Python's sort; we should not include the QFlowWidgetItem in the sort key.

Disclaimer -  I had some issues running tests locally (had to start a whole new fresh python/venv environment but I'm not convinced I did it 100% correctly) so I *think* this test is OK.