### PR TITLE
core: prune return None from inserted Python blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10.0']
         qt-binding: [pyqt5, pyside2]
       fail-fast: false
+      exclude:
+        - python-version: '3.10.0'
+          qt-binding: pyside2
     steps:
       - name: Install linux only test dependency
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10.0']
         qt-binding: [pyqt5, pyside2]
         exclude:
-          - os: ...
+          - os: ubuntu-latest
+            python-version: '3.10.0'
+            qt-binding: pyside2
+          - os: windows-latest
+            python-version: '3.10.0'
+            qt-binding: pyside2
+          - os: macos-latest
             python-version: '3.10.0'
             qt-binding: pyside2
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10.0']
         qt-binding: [pyqt5, pyside2]
+        exclude:
+          - os: ...
+            python-version: '3.10.0'
+            qt-binding: pyside2
       fail-fast: false
-      exclude:
-        - python-version: '3.10.0'
-          qt-binding: pyside2
     steps:
       - name: Install linux only test dependency
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10.0-rc.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10.0']
         qt-binding: [pyqt5, pyside2]
       fail-fast: false
     steps:
@@ -50,7 +50,6 @@ jobs:
           pip install https://github.com/nucleic/atom/tarball/main
           pip install https://github.com/nucleic/kiwi/tarball/main
       - name: Install Qt bindings
-        if: matrix.python-version != '3.10.0-rc.1'
         run: |
           pip install numpy qtpy '${{matrix.qt-binding}}'
       - name: Install extra dependencies
@@ -68,11 +67,7 @@ jobs:
           python setup.py develop
       - name: Install pytest
         run: |
-          pip install pytest pytest-cov
-      - name: Install pytest-qt
-        if: matrix.python-version != '3.10.0-rc.2'
-        run: |
-          pip install  pytest-qt
+          pip install pytest pytest-cov pytest-qt
       - name: Run tests (Windows, Mac)
         if: matrix.os != 'ubuntu-latest'
         run: python -X dev -m pytest tests --cov enaml --cov-report xml

--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -16,6 +16,8 @@ PY38 = POS_ONLY_ARGS = sys.version_info >= (3, 8)
 
 PY39 = sys.version_info >= (3, 9)
 
+PY310 = sys.version_info >= (3, 10)
+
 
 STRING_ESCAPE_SEQUENCE_RE = re.compile(r'''
     ( \\U........      # 8-digit hex escapes

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -1,11 +1,11 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013, Nucleic Development Team.
+# Copyright (c) 2013-2021, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-import sys
+import ast
 
 from . import compiler_common as cmn
 from .enaml_ast import Module
@@ -183,7 +183,7 @@ class EnamlCompiler(cmn.CompilerBase):
         # Generate the startup code for the module.
         cg.set_lineno(1)
         for start in STARTUP:
-            cg.insert_python_block(start)
+            cg.insert_python_block(ast.parse(start))
 
         # Create the template map.
         cg.build_map()
@@ -198,7 +198,7 @@ class EnamlCompiler(cmn.CompilerBase):
 
         # Generate the cleanup code for the module.
         for end in CLEANUP:
-            cg.insert_python_block(end)
+            cg.insert_python_block(ast.parse(end))
 
         # Finalize the ops and return the code object.
         cg.load_const(None)

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -9,7 +9,9 @@ Dates are written as DD/MM/YYYY
 - fix operator bindings in template instances PR #445
 - fix FlowLayout error with FlowItems that have non-zero stretch or ortho_stretch PR #448
 - add support for styling notebook tabs PR #452
-- drop official support for Python 3.6
+- drop official support for Python 3.6 and add minimal support for Python 3.10
+  As with earlier Python version, support for 3.10 is currently limited to running on
+  Python 3.10 excluding any features that were added on Python 3.10
 
 0.13.0 - 19/04/2021
 -------------------

--- a/tests/core/test_code_generator.py
+++ b/tests/core/test_code_generator.py
@@ -1,0 +1,29 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2021, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+"""Test for the code generator."""
+import ast
+import pytest
+
+from enaml.core.code_generator import CodeGenerator
+
+
+# Since we cannot have a return outside a function I am not sure we can ever
+# encounter a non-implicit return opcode.
+@pytest.mark.parametrize("source, return_on_lines", [
+    ("pass", []),
+    ("for i in range(10):\n    i", []),
+    ("with open(f) as f:\n   print(f.readlines())", []),
+])
+def test_python_block_insertion(source, return_on_lines):
+    cg = CodeGenerator()
+    cg.insert_python_block(ast.parse(source))
+    for i in cg.code_ops:
+        if getattr(i, "name", "") == "RETURN_VALUE":
+            assert i.lineno in return_on_lines
+
+

--- a/tests/core/test_code_generator.py
+++ b/tests/core/test_code_generator.py
@@ -25,5 +25,3 @@ def test_python_block_insertion(source, return_on_lines):
     for i in cg.code_ops:
         if getattr(i, "name", "") == "RETURN_VALUE":
             assert i.lineno in return_on_lines
-
-


### PR DESCRIPTION
In Python <3.10+, we were sure to find a single implicit return None per python block. Starting with 3.10, the implicit return None in with or try/except can be duplicated rather than being behind a jump. So we identify all explicit return None in the AST and prune implicit return None from all blocks in the bytecode control flow graph.