### PR TITLE
core: avoid generating empty block when trimming bytecode blocks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,14 +26,14 @@ environment:
         # 32-bit versions, PyQt and PySide2, latest
 
         - NAME: "32-bit, Latest "
-          PYTHON: "C:\\Python37"
-          PYTHON_VERSION: "3.7.3"
+          PYTHON: "C:\\Python39"
+          PYTHON_VERSION: "3.9"
           PYTHON_ARCH: "32"
           PYQT_VERSION: "5"
 
         - NAME: "PySide2"
-          PYTHON: "C:\\Python37-x64"
-          PYTHON_VERSION: "3.7.3"
+          PYTHON: "C:\\Python39-x64"
+          PYTHON_VERSION: "3.9"
           PYTHON_ARCH: "32"
           PYQT_VERSION: "None"
           QT_API: "pyside2"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,13 +26,13 @@ environment:
         # 32-bit versions, PyQt and PySide2, latest
 
         - NAME: "32-bit, Latest "
-          PYTHON: "C:\\Python39"
+          PYTHON: "C:\\Python38"
           PYTHON_VERSION: "3.9"
           PYTHON_ARCH: "32"
           PYQT_VERSION: "5"
 
         - NAME: "PySide2"
-          PYTHON: "C:\\Python39-x64"
+          PYTHON: "C:\\Python38"
           PYTHON_VERSION: "3.9"
           PYTHON_ARCH: "32"
           PYQT_VERSION: "None"

--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -479,6 +479,10 @@ class CodeGenerator(Atom):
                     and block[-1].lineno not in _inspector.lines
                 ):
                     del block[-2:]
+                    # If as a result of the trimming the block is empty, we add
+                    # a NOP to make sure it is valid still
+                    if not any(isinstance(i, bc.Instr) for i in block):
+                        block.append(bc.Instr("NOP"))
                     # If we have multiple block jump to the end of the last block
                     # to execute the code that may be appended to this block
                     if block is not last_block:

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,8 +3,9 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
-0.15.0 - Unreleased
+0.14.1 - Unreleased
 -------------------
+- fixes a bug in code generation for Pythoon 3.10 PR #476
 - fixes several bugs in corner cases of the Qt dock area PR #469
 - add python fstring scintilla tokens PR #470
 - address PyQt deprecation of accepting float values for pixel dimensions PR #471

--- a/tests/core/test_code_generator.py
+++ b/tests/core/test_code_generator.py
@@ -16,6 +16,7 @@ from enaml.core.code_generator import CodeGenerator
 # encounter a non-implicit return opcode.
 @pytest.mark.parametrize("source, return_on_lines", [
     ("pass", []),
+    ("if a:\n    print("")", []),
     ("for i in range(10):\n    i", []),
     ("with open(f) as f:\n   print(f.readlines())", []),
 ])
@@ -25,3 +26,4 @@ def test_python_block_insertion(source, return_on_lines):
     for i in cg.code_ops:
         if getattr(i, "name", "") == "RETURN_VALUE":
             assert i.lineno in return_on_lines
+    cg.to_code()


### PR DESCRIPTION
This is missing a test but should otherwise be good.