### PR TITLE
Add new declarative @observe which ignores 'create' events by default

### DIFF
--- a/enaml/core/declarative.py
+++ b/enaml/core/declarative.py
@@ -5,15 +5,18 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Event, Typed, Str, observe as default_observe
+from atom.api import ChangeType, Event, Typed, Str, observe as default_observe
 from atom.datastructures.api import sortedmap
 
-from .declarative_meta import DeclarativeMeta, D_CHANGE_TYPES
+from .declarative_meta import DeclarativeMeta
 from .expression_engine import ExpressionEngine
 from .object import Object, flag_generator, flag_property
 
+#: Declarative observe ignores create events
+OBSERVE_CHANGE_TYPES = ChangeType.ANY & ~ChangeType.CREATE
 
-def observe(*names, change_types=D_CHANGE_TYPES):
+
+def observe(*names, change_types=OBSERVE_CHANGE_TYPES):
     """ An observe decorator which ignores the created event by default.
 
     Parameters

--- a/enaml/core/declarative.py
+++ b/enaml/core/declarative.py
@@ -5,12 +5,27 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Event, Typed, Str
+from atom.api import Event, Typed, Str, observe as default_observe
 from atom.datastructures.api import sortedmap
 
-from .declarative_meta import DeclarativeMeta
+from .declarative_meta import DeclarativeMeta, D_CHANGE_TYPES
 from .expression_engine import ExpressionEngine
 from .object import Object, flag_generator, flag_property
+
+
+def observe(*names, change_types=D_CHANGE_TYPES):
+    """ An observe decorator which ignores the created event by default.
+
+    Parameters
+    ----------
+    *names
+        The str names of the attributes to observe on the object.
+        These must be of the form 'foo' or 'foo.bar'.
+    change_types
+        The flag specifying the type of changes to observe.
+
+    """
+    return default_observe(*names, change_types=change_types)
 
 
 def d_(member, readable=True, writable=True, final=True):

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -5,7 +5,11 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Atom, AtomMeta, DefaultValue, Member, Typed
+from atom.api import Atom, AtomMeta, ChangeType, DefaultValue, Member, Typed
+
+
+#: The Declarative engine ignores the create event type
+D_CHANGE_TYPES = ChangeType.ANY & ~ChangeType.CREATE
 
 
 class DeclarativeDefaultHandler(Atom):
@@ -88,7 +92,7 @@ def patch_d_member(member):
         new_mode = DefaultValue.CallObject_ObjectName
         member.set_default_value_mode(new_mode, handler)
     if metadata['d_readable']:
-        member.add_static_observer(declarative_change_handler)
+        member.add_static_observer(declarative_change_handler, D_CHANGE_TYPES)
 
 
 class DeclarativeMeta(AtomMeta):

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -8,7 +8,9 @@
 from atom.api import Atom, AtomMeta, ChangeType, DefaultValue, Member, Typed
 
 # The declarative engine only updates for these types of changes
-D_CHANGE_TYPES = ChangeType.UPDATE | ChangeType.PROPERTY | ChangeType.EVENT
+D_CHANGE_TYPES = (
+    ChangeType.UPDATE | ChangeType.PROPERTY | ChangeType.EVENT | ChangeType.DELETE
+)
 
 
 class DeclarativeDefaultHandler(Atom):

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -7,9 +7,8 @@
 #------------------------------------------------------------------------------
 from atom.api import Atom, AtomMeta, ChangeType, DefaultValue, Member, Typed
 
-
-#: The Declarative engine ignores the create event type
-D_CHANGE_TYPES = ChangeType.ANY & ~ChangeType.CREATE
+# The declarative engine only updates for these types of changes
+D_CHANGE_TYPES = ChangeType.UPDATE | ChangeType.PROPERTY | ChangeType.EVENT
 
 
 class DeclarativeDefaultHandler(Atom):
@@ -64,12 +63,11 @@ def declarative_change_handler(change):
 
     """
     # TODO think about whether this is the right place to filter on change_t
-    change_t = change['type']
-    if change_t == 'update' or change_t == 'event' or change_t == 'property':
-        owner = change['object']
-        engine = owner._d_engine
-        if engine is not None:
-            engine.write(owner, change['name'], change)
+    # NOTE: Filtering on change['type'] is done by atom
+    owner = change['object']
+    engine = owner._d_engine
+    if engine is not None:
+        engine.write(owner, change['name'], change)
 
 
 def patch_d_member(member):

--- a/enaml/core/dynamic_template.py
+++ b/enaml/core/dynamic_template.py
@@ -5,12 +5,12 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Dict, List, Str, Tuple, Typed, observe
+from atom.api import Dict, List, Str, Tuple, Typed
 
 from enaml.application import ScheduledTask, schedule
 from enaml.objectdict import ObjectDict
 
-from .declarative import Declarative, d_
+from .declarative import Declarative, d_, observe
 from .template import Template
 
 

--- a/enaml/scintilla/scintilla.py
+++ b/enaml/scintilla/scintilla.py
@@ -9,10 +9,10 @@ import uuid
 
 from atom.api import (
     Atom, Int, Constant, Enum, Event, Typed, List, ForwardTyped, Tuple,
-    Str, observe, set_default
+    Str, set_default
 )
 from enaml.image import Image
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.widgets.control import Control, ProxyControl
 
 

--- a/enaml/styling.py
+++ b/enaml/styling.py
@@ -10,10 +10,10 @@
 """
 from collections import defaultdict
 
-from atom.api import Atom, Str, Typed, observe
+from atom.api import Atom, Str, Typed
 
 from enaml.application import Application, deferred_call
-from enaml.core.declarative import Declarative, d_
+from enaml.core.declarative import Declarative, d_, observe
 
 
 class Setter(Declarative):

--- a/enaml/widgets/abstract_button.py
+++ b/enaml/widgets/abstract_button.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, Str, Coerced, Event, Typed, ForwardTyped, observe, set_default
+    Bool, Str, Coerced, Event, Typed, ForwardTyped, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.icon import Icon
 from enaml.layout.geometry import Size
 

--- a/enaml/widgets/action.py
+++ b/enaml/widgets/action.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Typed, ForwardTyped, Str, Bool, Event, observe
+from atom.api import Typed, ForwardTyped, Str, Bool, Event
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.icon import Icon
 
 from .toolkit_object import ToolkitObject, ProxyToolkitObject

--- a/enaml/widgets/action_group.py
+++ b/enaml/widgets/action_group.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, observe
+from atom.api import Bool, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .action import Action
 from .toolkit_object import ToolkitObject, ProxyToolkitObject

--- a/enaml/widgets/bounded_date.py
+++ b/enaml/widgets/bounded_date.py
@@ -7,9 +7,9 @@
 #------------------------------------------------------------------------------
 from datetime import date as pydate
 
-from atom.api import Typed, ForwardTyped, observe
+from atom.api import Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/bounded_datetime.py
+++ b/enaml/widgets/bounded_datetime.py
@@ -7,9 +7,9 @@
 #------------------------------------------------------------------------------
 from datetime import datetime as pydatetime
 
-from atom.api import Typed, ForwardTyped, observe
+from atom.api import Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/bounded_time.py
+++ b/enaml/widgets/bounded_time.py
@@ -7,9 +7,9 @@
 #------------------------------------------------------------------------------
 from datetime import datetime, time as pytime
 
-from atom.api import Typed, ForwardTyped, observe
+from atom.api import Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/button_group.py
+++ b/enaml/widgets/button_group.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, ForwardTyped, Typed, observe
+from atom.api import Bool, ForwardTyped, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_object import ToolkitObject, ProxyToolkitObject
 

--- a/enaml/widgets/color_dialog.py
+++ b/enaml/widgets/color_dialog.py
@@ -5,11 +5,11 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, observe
+from atom.api import Bool, Typed, ForwardTyped
 
 from enaml.application import Application
 from enaml.colors import ColorMember, Color
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_dialog import ToolkitDialog, ProxyToolkitDialog
 

--- a/enaml/widgets/combo_box.py
+++ b/enaml/widgets/combo_box.py
@@ -6,11 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, List, Int, Property, Str, Typed, ForwardTyped, set_default,
-    observe
+    Bool, List, Int, Property, Str, Typed, ForwardTyped, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/constraints_widget.py
+++ b/enaml/widgets/constraints_widget.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import List, ForwardTyped, Typed, observe
+from atom.api import List, ForwardTyped, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.constrainable import ConstrainableMixin, PolicyEnum
 
 from .widget import Widget, ProxyWidget

--- a/enaml/widgets/container.py
+++ b/enaml/widgets/container.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Coerced, ForwardTyped, Typed, observe, set_default
+from atom.api import Bool, Coerced, ForwardTyped, Typed, set_default
 
-from enaml.core.declarative import d_, d_func
+from enaml.core.declarative import d_, d_func, observe
 from enaml.layout.constrainable import ContentsConstrainableMixin
 from enaml.layout.geometry import Box
 from enaml.layout.layout_helpers import vbox

--- a/enaml/widgets/date_selector.py
+++ b/enaml/widgets/date_selector.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Str, Typed, ForwardTyped, observe, set_default
+from atom.api import Bool, Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .bounded_date import BoundedDate, ProxyBoundedDate
 

--- a/enaml/widgets/datetime_selector.py
+++ b/enaml/widgets/datetime_selector.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Str, Typed, ForwardTyped, observe, set_default
+from atom.api import Bool, Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .bounded_datetime import BoundedDatetime, ProxyBoundedDatetime
 

--- a/enaml/widgets/dock_area.py
+++ b/enaml/widgets/dock_area.py
@@ -8,11 +8,10 @@
 from contextlib import contextmanager
 
 from atom.api import (
-    Bool, Coerced, Enum, Typed, ForwardTyped, Str, Event, observe,
-    set_default
+    Bool, Coerced, Enum, Typed, ForwardTyped, Str, Event, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.dock_layout import DockLayout, DockLayoutOp
 from enaml.styling import StyleSheet
 

--- a/enaml/widgets/dock_item.py
+++ b/enaml/widgets/dock_item.py
@@ -5,12 +5,10 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Coerced, Event, Str, Bool, Range, Typed, ForwardTyped, observe
-)
+from atom.api import Coerced, Event, Str, Bool, Range, Typed, ForwardTyped
 
 from enaml.application import deferred_call
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.icon import Icon
 from enaml.layout.geometry import Size
 

--- a/enaml/widgets/dock_pane.py
+++ b/enaml/widgets/dock_pane.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    List, Enum, Str, Bool, Event, Typed, ForwardTyped, observe
-)
+from atom.api import List, Enum, Str, Bool, Event, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .container import Container
 from .widget import Widget, ProxyWidget

--- a/enaml/widgets/dual_slider.py
+++ b/enaml/widgets/dual_slider.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, Int, Range, Typed, ForwardTyped, observe
+from atom.api import Bool, Enum, Int, Range, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/field.py
+++ b/enaml/widgets/field.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, Int, Str, Enum, List, Typed, ForwardTyped, observe, set_default
+    Bool, Int, Str, Enum, List, Typed, ForwardTyped, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.validator import Validator
 
 from .control import Control, ProxyControl

--- a/enaml/widgets/file_dialog_ex.py
+++ b/enaml/widgets/file_dialog_ex.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, List, Str, Typed, ForwardTyped, observe
+from atom.api import Bool, Enum, List, Str, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_dialog import ToolkitDialog, ProxyToolkitDialog
 

--- a/enaml/widgets/flow_area.py
+++ b/enaml/widgets/flow_area.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Enum, Range, Coerced, Typed, ForwardTyped, observe, set_default
-)
+from atom.api import Enum, Range, Coerced, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.geometry import Box
 
 from .frame import Frame, ProxyFrame, Border

--- a/enaml/widgets/flow_item.py
+++ b/enaml/widgets/flow_item.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Enum, Range, Coerced, Typed, ForwardTyped, observe
+from atom.api import Enum, Range, Coerced, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.geometry import Size
 
 from .container import Container

--- a/enaml/widgets/form.py
+++ b/enaml/widgets/form.py
@@ -5,12 +5,12 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Int, observe
+from atom.api import Int
 
 from enaml.layout.constrainable import ConstraintMember
 from enaml.layout.layout_helpers import align, vertical, horizontal, spacer
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .container import Container
 

--- a/enaml/widgets/frame.py
+++ b/enaml/widgets/frame.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Atom, Enum, Range, ForwardTyped, Typed, observe
+from atom.api import Atom, Enum, Range, ForwardTyped, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .constraints_widget import ConstraintsWidget, ProxyConstraintsWidget
 

--- a/enaml/widgets/group_box.py
+++ b/enaml/widgets/group_box.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Str, Enum, Typed, ForwardTyped, observe
+from atom.api import Bool, Str, Enum, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .container import Container, ProxyContainer
 

--- a/enaml/widgets/h_group.py
+++ b/enaml/widgets/h_group.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Int, Typed, observe
+from atom.api import Bool, Int, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.layout_helpers import align, hbox
 from enaml.layout.spacers import Spacer
 

--- a/enaml/widgets/html.py
+++ b/enaml/widgets/html.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Str, Typed, ForwardTyped, observe, set_default
+from atom.api import Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/image_view.py
+++ b/enaml/widgets/image_view.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, observe, set_default
+from atom.api import Bool, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.image import Image
 
 from .control import Control, ProxyControl

--- a/enaml/widgets/label.py
+++ b/enaml/widgets/label.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Typed, ForwardTyped, Str, Enum, Event, observe, set_default
-)
+from atom.api import Typed, ForwardTyped, Str, Enum, Event, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/menu.py
+++ b/enaml/widgets/menu.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, Str, observe
+from atom.api import Bool, Typed, ForwardTyped, Str
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .action import Action
 from .action_group import ActionGroup

--- a/enaml/widgets/mpl_canvas.py
+++ b/enaml/widgets/mpl_canvas.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Typed, ForwardTyped, Bool, observe, set_default
+from atom.api import Typed, ForwardTyped, Bool, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/multiline_field.py
+++ b/enaml/widgets/multiline_field.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, Str, observe, set_default
+from atom.api import Bool, Typed, ForwardTyped, Str, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/notebook.py
+++ b/enaml/widgets/notebook.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Enum, Bool, Typed, ForwardTyped, Str, observe, set_default
+    Enum, Bool, Typed, ForwardTyped, Str, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .constraints_widget import ConstraintsWidget, ProxyConstraintsWidget
 from .page import Page

--- a/enaml/widgets/object_combo.py
+++ b/enaml/widgets/object_combo.py
@@ -6,10 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, Callable, List, Value, Typed, ForwardTyped, set_default, observe
+    Bool, Callable, List, Value, Typed, ForwardTyped, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from .control import Control, ProxyControl
 
 

--- a/enaml/widgets/page.py
+++ b/enaml/widgets/page.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Str, Bool, Event, Typed, ForwardTyped, observe
+from atom.api import Str, Bool, Event, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.icon import Icon
 
 from .container import Container

--- a/enaml/widgets/popup_view.py
+++ b/enaml/widgets/popup_view.py
@@ -6,12 +6,11 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Bool, Coerced, Enum, Float, Event, Int, Typed, ForwardTyped, observe,
-    set_default
+    Bool, Coerced, Enum, Float, Event, Int, Typed, ForwardTyped, set_default
 )
 
 from enaml.application import deferred_call
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.geometry import Pos, PosF
 
 from .container import Container

--- a/enaml/widgets/progress_bar.py
+++ b/enaml/widgets/progress_bar.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Typed, ForwardTyped, Property, Bool, Int, observe, set_default
-)
+from atom.api import Typed, ForwardTyped, Property, Bool, Int, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/push_button.py
+++ b/enaml/widgets/push_button.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Typed, ForwardTyped, observe
+from atom.api import Bool, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .abstract_button import AbstractButton, ProxyAbstractButton
 from .menu import Menu

--- a/enaml/widgets/scroll_area.py
+++ b/enaml/widgets/scroll_area.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Enum, Bool, Typed, ForwardTyped, observe, set_default
+from atom.api import Enum, Bool, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .container import Container
 from .frame import Frame, ProxyFrame, Border

--- a/enaml/widgets/separator.py
+++ b/enaml/widgets/separator.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Range, Enum, Typed, ForwardTyped, observe
+from atom.api import Bool, Range, Enum, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from .control import Control, ProxyControl
 
 

--- a/enaml/widgets/slider.py
+++ b/enaml/widgets/slider.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, Int, Range, Typed, ForwardTyped, observe
+from atom.api import Bool, Enum, Int, Range, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/spin_box.py
+++ b/enaml/widgets/spin_box.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Int, Bool, Range, Str, Typed, ForwardTyped, observe, set_default
-)
+from atom.api import Int, Bool, Range, Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/split_item.py
+++ b/enaml/widgets/split_item.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Range, Value, Typed, ForwardTyped, observe
+from atom.api import Bool, Range, Value, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .container import Container
 from .widget import Widget, ProxyWidget

--- a/enaml/widgets/splitter.py
+++ b/enaml/widgets/splitter.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, Typed, ForwardTyped, observe, set_default
+from atom.api import Bool, Enum, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .constraints_widget import ConstraintsWidget, ProxyConstraintsWidget
 from .split_item import SplitItem

--- a/enaml/widgets/stack.py
+++ b/enaml/widgets/stack.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Atom, Enum, Int, Range, Typed, ForwardTyped, observe, set_default
-)
+from atom.api import Atom, Enum, Int, Range, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .constraints_widget import ConstraintsWidget, ProxyConstraintsWidget
 from .stack_item import StackItem

--- a/enaml/widgets/status_bar.py
+++ b/enaml/widgets/status_bar.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Typed, ForwardTyped, Bool, observe
+from atom.api import Typed, ForwardTyped, Bool
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .status_item import StatusItem
 from .widget import Widget, ProxyWidget

--- a/enaml/widgets/status_item.py
+++ b/enaml/widgets/status_item.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Typed, ForwardTyped, Enum, Range, observe
+from atom.api import Typed, ForwardTyped, Enum, Range
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_object import ToolkitObject, ProxyToolkitObject
 from .widget import Widget

--- a/enaml/widgets/time_selector.py
+++ b/enaml/widgets/time_selector.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Str, Typed, ForwardTyped, observe, set_default
+from atom.api import Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .bounded_time import BoundedTime, ProxyBoundedTime
 

--- a/enaml/widgets/timer.py
+++ b/enaml/widgets/timer.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Event, Int, ForwardTyped, Typed, observe
+from atom.api import Bool, Event, Int, ForwardTyped, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_object import ToolkitObject, ProxyToolkitObject
 

--- a/enaml/widgets/tool_bar.py
+++ b/enaml/widgets/tool_bar.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, List, Typed, ForwardTyped, observe
+from atom.api import Bool, Enum, List, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .action import Action
 from .action_group import ActionGroup

--- a/enaml/widgets/tool_button.py
+++ b/enaml/widgets/tool_button.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Bool, Enum, Typed, ForwardTyped, observe
+from atom.api import Bool, Enum, Typed, ForwardTyped
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .abstract_button import AbstractButton, ProxyAbstractButton
 

--- a/enaml/widgets/toolkit_dialog.py
+++ b/enaml/widgets/toolkit_dialog.py
@@ -5,12 +5,10 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    Bool, Str, Typed, ForwardTyped, Event, Callable, observe
-)
+from atom.api import Bool, Str, Typed, ForwardTyped, Event, Callable
 
 from enaml.application import deferred_call
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .toolkit_object import ToolkitObject, ProxyToolkitObject
 

--- a/enaml/widgets/v_group.py
+++ b/enaml/widgets/v_group.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Int, Typed, observe
+from atom.api import Int, Typed
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.layout.layout_helpers import align, vbox
 from enaml.layout.spacers import Spacer
 

--- a/enaml/widgets/vtk_canvas.py
+++ b/enaml/widgets/vtk_canvas.py
@@ -5,11 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import (
-    List, Typed, ForwardTyped, ForwardInstance, observe, set_default
-)
+from atom.api import List, Typed, ForwardTyped, ForwardInstance, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/web_view.py
+++ b/enaml/widgets/web_view.py
@@ -5,9 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from atom.api import Str, Typed, ForwardTyped, observe, set_default
+from atom.api import Str, Typed, ForwardTyped, set_default
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 
 from .control import Control, ProxyControl
 

--- a/enaml/widgets/widget.py
+++ b/enaml/widgets/widget.py
@@ -7,12 +7,10 @@
 #------------------------------------------------------------------------------
 from enum import IntFlag
 
-from atom.api import (
-    Bool, Str, Coerced, Typed, ForwardTyped, observe
-)
+from atom.api import Bool, Str, Coerced, Typed, ForwardTyped
 
 from enaml.colors import ColorMember
-from enaml.core.declarative import d_, d_func
+from enaml.core.declarative import d_, d_func, observe
 from enaml.fonts import FontMember
 from enaml.layout.geometry import Size
 from enaml.styling import Stylable

--- a/enaml/widgets/window.py
+++ b/enaml/widgets/window.py
@@ -6,11 +6,10 @@
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
 from atom.api import (
-    Atom, Str, Enum, Bool, Event, Coerced, Typed, ForwardTyped, observe,
-    set_default
+    Atom, Str, Enum, Bool, Event, Coerced, Typed, ForwardTyped, set_default
 )
 
-from enaml.core.declarative import d_
+from enaml.core.declarative import d_, observe
 from enaml.icon import Icon
 from enaml.layout.geometry import Pos, Rect, Size
 

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -9,6 +9,7 @@ Dates are written as DD/MM/YYYY
 - fixes several bugs in corner cases of the Qt dock area PR #469
 - add python fstring scintilla tokens PR #470
 - address PyQt deprecation of accepting float values for pixel dimensions PR #471 and #481
+- add new declarative @observe which ignores 'create' events by default PR #479
 
 0.14.0 - 21/11/2021
 -------------------

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -9,7 +9,9 @@ Dates are written as DD/MM/YYYY
 - fixes several bugs in corner cases of the Qt dock area PR #469
 - add python fstring scintilla tokens PR #470
 - address PyQt deprecation of accepting float values for pixel dimensions PR #471 and #481
-- add new declarative @observe which ignores 'create' events by default PR #479
+- add new declarative @observe which ignores 'create' and 'container' events by default PR #479
+- use atom builtin filtering mechanism to avoid refreshing the declarative engine on 
+  'create' and 'container' event PR # 479
 
 0.14.0 - 21/11/2021
 -------------------


### PR DESCRIPTION
In order to avoid unnecessary calls to to `_update_proxy` (which by default only handles the `update` event type anyways), this change adds a new `observe` decorator in `enaml.core.declarative` that updates the default `change_types` flag to ignore `create` events. The widget declarations were updated to use the new import instead of the one from atom.api.  

The static observer added by the declarative metaclass will also ignore `created` events.

Any 3rd-party code using the original atom.api for custom members will be unchanged unless it relied on a create event from a superclass member. 

If someone needs the create event, either use the `observe` decorator from the atom.api or pass in the `change_types` flags for the needed. If the member had `@observe` on a super class, you can re-bind it with new flags to change the events triggerd.