### PR TITLE
Coerce QTimer.singleShot ms argument to int

### DIFF
--- a/enaml/qt/q_deferred_caller.py
+++ b/enaml/qt/q_deferred_caller.py
@@ -70,4 +70,4 @@ def timedCall(ms, callback, *args, **kwargs):
     if QThread.currentThread() != QApplication.instance().thread():
         deferredCall(timedCall, ms, callback, *args, **kwargs)
     else:
-        QTimer.singleShot(ms, lambda: callback(*args, **kwargs))
+        QTimer.singleShot(int(ms), lambda: callback(*args, **kwargs))


### PR DESCRIPTION
PyQt seems to not do any more casting.. This was reported on the inkcut forum https://inkcut.org/t/it-isnt-inkcut/104/post/381/ and I was able to reproduce it.