### PR TITLE
Update scintilla for Qt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,14 @@ jobs:
         if: matrix.python-version == '3.9'
         run: |
           pip install matplotlib ipython qtconsole
-      - name: Install QScintilla
-        if: matrix.python-version == '3.9' && matrix.qt-binding == 'pyqt'
+      - name: Install QScintilla (Qt5)
+        if: matrix.python-version == '3.9' && matrix.qt-binding == 'pyqt' && matrix.qt-version== 5
         run: |
-          pip install Cython QScintilla
+          pip install QScintilla
+      - name: Install QScintilla (Qt6)
+        if: matrix.python-version == '3.9' && matrix.qt-binding == 'pyqt' && matrix.qt-version== 6
+        run: |
+          pip install PyQt6-QScintilla
       - name: Install pytest
         run: |
           pip install pytest pytest-cov pytest-qt

--- a/enaml/qt/Qsci.py
+++ b/enaml/qt/Qsci.py
@@ -1,0 +1,19 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2022, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+#------------------------------------------------------------------------------
+from . import QT_API, PYSIDE2_API, PYQT5_API, PYQT6_API
+
+if QT_API in PYSIDE2_API:
+    msg = 'the Qt Scintilla widget is only available when using PyQt'
+    raise ImportError(msg)
+
+if QT_API in PYQT6_API:
+    from PyQt6.Qsci import *
+elif QT_API in PYQT5_API:
+    from PyQt5.Qsci import *
+else:
+    from QScintilla import *

--- a/enaml/qt/Qsci.py
+++ b/enaml/qt/Qsci.py
@@ -5,15 +5,12 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from . import QT_API, PYSIDE2_API, PYQT5_API, PYQT6_API
-
-if QT_API in PYSIDE2_API:
-    msg = 'the Qt Scintilla widget is only available when using PyQt'
-    raise ImportError(msg)
+from . import QT_API, PYQT5_API, PYQT6_API
 
 if QT_API in PYQT6_API:
     from PyQt6.Qsci import *
 elif QT_API in PYQT5_API:
     from PyQt5.Qsci import *
 else:
-    from QScintilla import *
+    msg = 'the Qt Scintilla widget is only available when using PyQt5 or PyQt6'
+    raise ImportError(msg)

--- a/enaml/qt/__init__.py
+++ b/enaml/qt/__init__.py
@@ -12,5 +12,4 @@ from qtpy import (
     PYQT6_API,
     PYSIDE6_API,
     QT_VERSION,
-    QT6 as IS_QT6
 )

--- a/enaml/qt/__init__.py
+++ b/enaml/qt/__init__.py
@@ -12,4 +12,5 @@ from qtpy import (
     PYQT6_API,
     PYSIDE6_API,
     QT_VERSION,
+    QT6 as IS_QT6
 )

--- a/enaml/qt/docking/q_icon_widget.py
+++ b/enaml/qt/docking/q_icon_widget.py
@@ -8,7 +8,6 @@
 from enaml.qt.QtCore import QSize
 from enaml.qt.QtGui import QIcon, QPainter
 from enaml.qt.QtWidgets import QFrame
-from enaml.qt import IS_QT6
 
 
 class QIconWidget(QFrame):

--- a/enaml/qt/docking/q_icon_widget.py
+++ b/enaml/qt/docking/q_icon_widget.py
@@ -8,6 +8,7 @@
 from enaml.qt.QtCore import QSize
 from enaml.qt.QtGui import QIcon, QPainter
 from enaml.qt.QtWidgets import QFrame
+from enaml.qt import IS_QT6
 
 
 class QIconWidget(QFrame):
@@ -93,6 +94,8 @@ class QIconWidget(QFrame):
         size = self._icon_size
         if not size.isValid():
             size = QSize(16, 16)
+        if IS_QT6:
+            return size
         left, top, right, bottom = self.getContentsMargins()
         return size + QSize(left + right, top + bottom)
 

--- a/enaml/qt/docking/q_icon_widget.py
+++ b/enaml/qt/docking/q_icon_widget.py
@@ -94,10 +94,8 @@ class QIconWidget(QFrame):
         size = self._icon_size
         if not size.isValid():
             size = QSize(16, 16)
-        if IS_QT6:
-            return size
-        left, top, right, bottom = self.getContentsMargins()
-        return size + QSize(left + right, top + bottom)
+        m = self.contentsMargins()
+        return size + QSize(m.left() + m.right(), m.top() + m.bottom())
 
     def paintEvent(self, event):
         """ Handle the paint event for the widget.

--- a/enaml/qt/qt_scintilla.py
+++ b/enaml/qt/qt_scintilla.py
@@ -1,15 +1,10 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from . import QT_API, PYSIDE2_API, PYQT5_API
-if QT_API in PYSIDE2_API:
-    msg = 'the Qt Scintilla widget is only available when using PyQt'
-    raise ImportError(msg)
-
 import logging
 import sys
 import weakref
@@ -20,11 +15,7 @@ from enaml.colors import parse_color
 from enaml.fonts import parse_font
 from enaml.scintilla.scintilla import ProxyScintilla
 
-if QT_API in PYQT5_API:
-    from PyQt5 import Qsci
-else:
-    import QScintilla as Qsci
-
+from . import QT_API, PYQT6_API, Qsci
 from .QtGui import QColor, QFont
 
 from .q_resource_helpers import (QColor_from_Color, QFont_from_Font,
@@ -48,6 +39,17 @@ elif sys.platform == 'darwin':
     DEFAULT_EOL = 'cr'
 else:
     DEFAULT_EOL = 'lf'
+
+if QT_API in PYQT6_API:
+    AutoCompletionUseSingle = QsciScintilla.AutoCompletionUseSingle
+    AutoCompletionSource = QsciScintilla.AutoCompletionSource
+    IndicatorStyle = QsciScintilla.IndicatorStyle
+    NumberMargin = QsciScintilla.MarginType.NumberMargin
+else:
+    AutoCompletionUseSingle = QsciScintilla
+    AutoCompletionSource = QsciScintilla
+    IndicatorStyle = QsciScintilla
+    NumberMargin = QsciScintilla.NumberMargin
 
 
 EOL_MODE = {
@@ -79,38 +81,38 @@ WHITE_SPACE = {
 }
 
 AUTOCOMPLETION_USE_SINGLE = {
-    'never': QsciScintilla.AcusNever,
-    'explicit': QsciScintilla.AcusExplicit,
-    'always': QsciScintilla.AcusAlways,
+    'never': AutoCompletionUseSingle.AcusNever,
+    'explicit': AutoCompletionUseSingle.AcusExplicit,
+    'always': AutoCompletionUseSingle.AcusAlways,
 }
 
 AUTOCOMPLETION_SOURCE = {
-    'none': QsciScintilla.AcsNone,
-    'all': QsciScintilla.AcsAll,
-    'document': QsciScintilla.AcsDocument,
-    'apis': QsciScintilla.AcsAPIs,
+    'none': AutoCompletionSource.AcsNone,
+    'all': AutoCompletionSource.AcsAll,
+    'document': AutoCompletionSource.AcsDocument,
+    'apis': AutoCompletionSource.AcsAPIs,
 }
 
 INDICATOR_STYLE = {
-    'plain': QsciScintilla.PlainIndicator,
-    'squiggle': QsciScintilla.SquiggleIndicator,
-    'tt': QsciScintilla.TTIndicator,
-    'diagonal': QsciScintilla.DiagonalIndicator,
-    'strike': QsciScintilla.StrikeIndicator,
-    'hidden': QsciScintilla.HiddenIndicator,
-    'box': QsciScintilla.BoxIndicator,
-    'round_box': QsciScintilla.RoundBoxIndicator,
-    'straight_box': QsciScintilla.StraightBoxIndicator,
-    'full_box': QsciScintilla.FullBoxIndicator,
-    'dashes': QsciScintilla.DashesIndicator,
-    'dots': QsciScintilla.DotsIndicator,
-    'squiggle_low': QsciScintilla.SquiggleLowIndicator,
-    'dot_box': QsciScintilla.DotBoxIndicator,
-    'thick_composition': QsciScintilla.ThickCompositionIndicator,
-    'thin_composition': QsciScintilla.ThinCompositionIndicator,
-    'text_color': QsciScintilla.TextColorIndicator,
-    'triangle': QsciScintilla.TriangleIndicator,
-    'triangle_character': QsciScintilla.TriangleCharacterIndicator,
+    'plain': IndicatorStyle.PlainIndicator,
+    'squiggle': IndicatorStyle.SquiggleIndicator,
+    'tt': IndicatorStyle.TTIndicator,
+    'diagonal': IndicatorStyle.DiagonalIndicator,
+    'strike': IndicatorStyle.StrikeIndicator,
+    'hidden': IndicatorStyle.HiddenIndicator,
+    'box': IndicatorStyle.BoxIndicator,
+    'round_box': IndicatorStyle.RoundBoxIndicator,
+    'straight_box': IndicatorStyle.StraightBoxIndicator,
+    'full_box': IndicatorStyle.FullBoxIndicator,
+    'dashes': IndicatorStyle.DashesIndicator,
+    'dots': IndicatorStyle.DotsIndicator,
+    'squiggle_low': IndicatorStyle.SquiggleLowIndicator,
+    'dot_box': IndicatorStyle.DotBoxIndicator,
+    'thick_composition': IndicatorStyle.ThickCompositionIndicator,
+    'thin_composition': IndicatorStyle.ThinCompositionIndicator,
+    'text_color': IndicatorStyle.TextColorIndicator,
+    'triangle': IndicatorStyle.TriangleIndicator,
+    'triangle_character': IndicatorStyle.TriangleCharacterIndicator,
 }
 
 NUMBER_MARGIN = 0
@@ -517,7 +519,7 @@ class QtScintilla(QtControl, ProxyScintilla):
 
         """
         w = self.widget
-        w.setMarginType(NUMBER_MARGIN, QsciScintilla.NumberMargin)
+        w.setMarginType(NUMBER_MARGIN, NumberMargin)
         self.widget.setMarginWidth(
             NUMBER_MARGIN, "0"+str(max(10, w.lines())) if show else "")
 

--- a/enaml/qt/scintilla_lexers.py
+++ b/enaml/qt/scintilla_lexers.py
@@ -1,19 +1,11 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
-from . import QT_API, PYSIDE2_API, PYQT5_API
-if QT_API in PYSIDE2_API:
-    msg = 'the Qt Scintilla widget is only available when using PyQt'
-    raise ImportError(msg)
-
-if QT_API in PYQT5_API:
-    from PyQt5 import Qsci
-else:
-    import QScintilla as Qsci
+from . import Qsci
 
 
 class PythonLexer(Qsci.QsciLexerPython):

--- a/examples/applib/live_editor.enaml
+++ b/examples/applib/live_editor.enaml
@@ -58,7 +58,9 @@ enamldef Main(Window):
 
     func handle_uncaught_exception(exc, value, tb):
         """Send uncaught exception to the model to avoid crashing the editor."""
-        editor_model.traceback = "".join(traceback.format_exception(exc, value, tb))
+        msg = "".join(traceback.format_exception(exc, value, tb))
+        print(msg) # Print to console in case there was a startup error
+        editor_model.traceback = msg
 
     initialized::
         sys.excepthook = handle_uncaught_exception


### PR DESCRIPTION
Builds on #475. It seems like PyQt6 changes how enums values are exposed.  

One fix in q_icon_widget that may need addressed https://doc-snapshots.qt.io/qt6-dev/qlayout.html#getContentsMargins seems to have moved from QWidget.