### PR TITLE
Enaml qt6 fixes (for deprecated methods)

### DIFF
--- a/enaml/qt/compat.py
+++ b/enaml/qt/compat.py
@@ -9,14 +9,18 @@ from qtpy.QtCore import QEvent
 
 from . import QT_API, PYQT6_API, QT_VERSION
 
-def coerce_to_qevent_type(event_value):
-    if QT_API in PYQT6_API:
-        return event_value
-    return QEvent.Type(event_value)
 
-
-def global_pos_from_event(event):
-    if QT_VERSION[0] == "6":
+if QT_VERSION[0] == '6':
+    def global_pos_from_event(event):
         return event.globalPosition().toPoint()
-    else:
+else:
+    def global_pos_from_event(event):
         return event.globalPos()
+
+
+if QT_API in PYQT6_API:
+    def coerce_to_qevent_type(event_value):
+        return event_value
+else:
+    def coerce_to_qevent_type(event_value):
+        return QEvent.Type(event_value)

--- a/enaml/qt/docking/__init__.py
+++ b/enaml/qt/docking/__init__.py
@@ -8,7 +8,9 @@
 from .. import QT_VERSION
 
 
-def hover_event_pos(event):
-    if QT_VERSION[0] == "6":
+if QT_VERSION[0] == "6":
+    def hover_event_pos(event):
         return event.position().toPoint()
-    return event.pos()
+else:
+    def hover_event_pos(event):
+        return event.pos()

--- a/enaml/qt/docking/__init__.py
+++ b/enaml/qt/docking/__init__.py
@@ -1,7 +1,14 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+from .. import QT_VERSION
+
+
+def hover_event_pos(event):
+    if QT_VERSION[0] == "6":
+        return event.position().toPoint()
+    return event.pos()

--- a/enaml/qt/docking/layout_builder.py
+++ b/enaml/qt/docking/layout_builder.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -43,9 +43,11 @@ def ensure_on_screen(rect):
         The potentially adjusted QRect which fits on the screen.
 
     """
-    d = QApplication.desktop()
     pos = rect.topLeft()
-    drect = d.screenGeometry(pos)
+    screen = QApplication.screenAt(pos)
+    if screen is None:
+        screen = QApplication.primaryScreen()
+    drect = screen.availableGeometry()
     if not drect.contains(pos):
         x = pos.x()
         if x < drect.x() or x > drect.right():

--- a/enaml/qt/docking/q_dock_frame.py
+++ b/enaml/qt/docking/q_dock_frame.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017 Nucleic Development Team.
+# Copyright (c) 2013-2022 Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,6 +9,8 @@ from atom.api import Atom, Bool, Int, Typed
 
 from enaml.qt.QtCore import Qt, QEvent, QRect, QSize, QPoint, QMargins, Signal
 from enaml.qt.QtWidgets import QApplication, QFrame
+
+from . import hover_event_pos
 
 
 class QDockFrame(QFrame):
@@ -267,7 +269,7 @@ class QDockFrame(QFrame):
             return
         if state.resize_border != self.NoBorder:
             return
-        self._refreshCursor(event.pos())
+        self._refreshCursor(hover_event_pos(event))
         event.accept()
 
     def titleBarMousePressEvent(self, event):

--- a/enaml/qt/docking/q_dock_tab_widget.py
+++ b/enaml/qt/docking/q_dock_tab_widget.py
@@ -8,7 +8,7 @@
 from weakref import ref
 
 from enaml.qt.compat import global_pos_from_event
-from enaml.qt.QtCore import Qt, QPoint, QSize, QMetaObject, QEvent, QRect
+from enaml.qt.QtCore import Qt, QPoint, QPointF, QSize, QMetaObject, QEvent, QRect
 from enaml.qt.QtGui import (
     QMouseEvent, QResizeEvent, QCursor, QPainter, QPixmap
 )
@@ -335,7 +335,8 @@ class QDockTabBar(QTabBar):
             # The button must be Qt.LeftButton, not event.button().
             btn = Qt.LeftButton
             mod = event.modifiers()
-            evt = QMouseEvent(QEvent.MouseButtonRelease, pos, btn, btn, mod)
+            evt = QMouseEvent(QEvent.MouseButtonRelease, QPointF(pos), btn,
+                              btn, mod)
             QApplication.sendEvent(self, evt)
             container = self.parent().widget(self.currentIndex())
             container.untab(global_pos_from_event(event))

--- a/enaml/qt/docking/q_dock_window.py
+++ b/enaml/qt/docking/q_dock_window.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2017, Nucleic Development Team.
+# Copyright (c) 2013-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -22,6 +22,8 @@ from .xbms import (
     CLOSE_BUTTON, MAXIMIZE_BUTTON, RESTORE_BUTTON, LINKED_BUTTON,
     UNLINKED_BUTTON
 )
+
+from . import hover_event_pos
 
 
 class QDockWindowButtons(QFrame):
@@ -430,7 +432,8 @@ class QDockWindow(QDockFrame):
         over the dock window buttons.
 
         """
-        if self._title_buttons.geometry().contains(event.pos()):
+        pos = hover_event_pos(event)
+        if self._title_buttons.geometry().contains(pos):
             self.unsetCursor()
         else:
             super(QDockWindow, self).hoverMoveEvent(event)

--- a/enaml/qt/q_popup_view.py
+++ b/enaml/qt/q_popup_view.py
@@ -726,6 +726,7 @@ class QPopupView(QWidget):
         if state.close_on_click:
             path = state.path
             pos = event.pos()
+            posf = QPointF(pos)
             rect = self.rect()
             win_type = self.windowType()
             if win_type == Qt.Popup:
@@ -733,11 +734,11 @@ class QPopupView(QWidget):
                     super(QPopupView, self).mousePressEvent(event)
                 else:
                     path = state.path
-                    if not path.isEmpty() and not path.contains(pos):
+                    if not path.isEmpty() and not path.contains(posf):
                         event.accept()
                         self.close()
             elif win_type == Qt.ToolTip or win_type == Qt.Window:
-                if path.isEmpty() or path.contains(pos):
+                if path.isEmpty() or path.contains(posf):
                     event.accept()
                     self.close()
 

--- a/enaml/qt/qt_date_selector.py
+++ b/enaml/qt/qt_date_selector.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+import datetime
+
 from atom.api import Typed
 
 from enaml.widgets.date_selector import ProxyDateSelector
@@ -52,7 +54,8 @@ class QtDateSelector(QtBoundedDate, ProxyDateSelector):
             The current control date as a date object.
 
         """
-        return self.widget.date().toPython()
+        date = self.widget.date()
+        return datetime.date(date.year(), date.month(), date.day())
 
     def set_minimum(self, date):
         """ Set the widget's minimum date.

--- a/enaml/qt/qt_time_selector.py
+++ b/enaml/qt/qt_time_selector.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+import datetime
+
 from atom.api import Typed
 
 from enaml.widgets.time_selector import ProxyTimeSelector
@@ -51,7 +53,9 @@ class QtTimeSelector(QtBoundedTime, ProxyTimeSelector):
             The current control time as a time object.
 
         """
-        return self.widget.time().toPython()
+        time = self.widget.time()
+        return datetime.time(time.hour(), time.minute(), time.second(),
+                             time.msec() * 1000)
 
     def set_minimum(self, time):
         """ Set the widget's minimum time.


### PR DESCRIPTION
I discovered all of these issues when testing with the desktop example. 

I have started testing against my application (psiexperiment) and may have more to report later.

### Examples to check
- [ ] aliases
- [ ] applib
- [ ] dynamic
- [ ] functions
- [ ] layout
- [ ] stdlib
- [ ] styling
- [ ] templates
- [ ] tutorial
- [x] widgets
- [ ] workbench

### Broken examples
- [ ] `drag_and_drop.enaml` (drag and drop broken)
- [ ] `file_dialog.enaml` (browse button broken)
- [ ] `flow_area.enaml` (changing flow layout)
- [ ] `image_view.enaml` (set to None)
- [ ] `ipython_console.enaml` (possibly just need to install qtconsole),
- [ ] `vtk_canvas.enaml` (most likely need to install vtk)
- [ ] `web_view.enaml`