### PR TITLE
Show declarative stack if an error occurs during initialization or change event

### DIFF
--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -548,7 +548,9 @@ def gen_child_def_node(cg, node, local_names):
     cg.load_const(node.identifier)
     cg.load_fast(SCOPE_KEY)
     cg.load_const(store_locals)                 # helper -> class -> identifier -> key -> bool
-    cg.call_function(4)                         # node
+    cg.load_const(node.filename)
+    cg.load_const(node.lineno)
+    cg.call_function(6)                         # node
 
 
 def gen_template_inst_node(cg, node, local_names):
@@ -893,6 +895,14 @@ class CompilerBase(ASTVisitor):
 
     #: The code generator to use for this compiler.
     code_generator = Typed(CodeGenerator)
+
+    def visit(self, node, *args, **kwargs):
+        """ Update the source file of the node.
+
+        """
+        if not node.filename:
+            node.filename = self.filename
+        return super().visit(node, *args, **kwargs)
 
     def _default_code_generator(self):
         """ Create the default code generator instance.

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -547,8 +547,8 @@ def gen_child_def_node(cg, node, local_names):
     cg.rot_two()
     cg.load_const(node.identifier)
     cg.load_fast(SCOPE_KEY)
-    cg.load_const(store_locals)                 # helper -> class -> identifier -> key -> bool
-    cg.load_const((cg.filename, node.lineno))
+    cg.load_const(store_locals)
+    cg.load_const((cg.filename, node.lineno))   # helper -> class -> identifier -> key -> bool -> location
     cg.call_function(5)                         # node
 
 

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -548,9 +548,8 @@ def gen_child_def_node(cg, node, local_names):
     cg.load_const(node.identifier)
     cg.load_fast(SCOPE_KEY)
     cg.load_const(store_locals)                 # helper -> class -> identifier -> key -> bool
-    cg.load_const(node.filename)
-    cg.load_const(node.lineno)
-    cg.call_function(6)                         # node
+    cg.load_const((node.filename, node.lineno))
+    cg.call_function(5)                         # node
 
 
 def gen_template_inst_node(cg, node, local_names):
@@ -737,7 +736,8 @@ def gen_operator_binding(cg, node, index, name):
         cg.load_const(node.operator)
         cg.load_const(code)
         cg.load_fast(F_GLOBALS)
-        cg.call_function(6)
+        cg.load_const((cg.filename, node.lineno))
+        cg.call_function(7)
         cg.pop_top()
 
 

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -618,7 +618,8 @@ def gen_template_inst_node(cg, node, local_names):
     cg.load_const(starname)
     cg.load_fast(SCOPE_KEY)
     cg.load_const(bool(node.body))
-    cg.call_function(5)
+    cg.load_const((cg.filename, node.lineno))
+    cg.call_function(6)
 
 
 def sanitize_operator_code(filename, mode, ast):

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -548,7 +548,7 @@ def gen_child_def_node(cg, node, local_names):
     cg.load_const(node.identifier)
     cg.load_fast(SCOPE_KEY)
     cg.load_const(store_locals)                 # helper -> class -> identifier -> key -> bool
-    cg.load_const((node.filename, node.lineno))
+    cg.load_const((cg.filename, node.lineno))
     cg.call_function(5)                         # node
 
 
@@ -895,14 +895,6 @@ class CompilerBase(ASTVisitor):
 
     #: The code generator to use for this compiler.
     code_generator = Typed(CodeGenerator)
-
-    def visit(self, node, *args, **kwargs):
-        """ Update the source file of the node.
-
-        """
-        if not node.filename:
-            node.filename = self.filename
-        return super().visit(node, *args, **kwargs)
 
     def _default_code_generator(self):
         """ Create the default code generator instance.

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -272,7 +272,7 @@ def template_node(scope_key):
     return node
 
 
-def template_inst_node(templ, names, starname, scope_key, copy):
+def template_inst_node(templ, names, starname, scope_key, copy, source_location=None):
     """ Create and return a new template inst node.
 
     Parameters
@@ -296,6 +296,9 @@ def template_inst_node(templ, names, starname, scope_key, copy):
         copy will be required when the template instance has bindings
         so that the closure keys remain isolated to this instance.
 
+    source_location: tuple
+        A tuple of the filename and lineno where the node is defined.
+
     Returns
     -------
     result : TemplateInstNode
@@ -307,6 +310,7 @@ def template_inst_node(templ, names, starname, scope_key, copy):
     node.names = names
     node.starname = starname
     node.scope_key = scope_key
+    node.source_location = source_location
     return node
 
 

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -166,7 +166,7 @@ def add_storage(node, name, store_type, kind):
     setattr(klass, name, new)
 
 
-def declarative_node(klass, identifier, scope_key, store_locals):
+def declarative_node(klass, identifier, scope_key, store_locals, filename, lineno):
     """ Create and return a DeclarativeNode for the given klass.
 
     Parameters
@@ -184,6 +184,12 @@ def declarative_node(klass, identifier, scope_key, store_locals):
         Whether instances of the class should store the local scope in
         their storage map.
 
+    filename: str
+        The name of the file where the node is defined.
+
+    lineno: int
+        The line number within the file where the node is defined.
+
     Returns
     -------
     result : DeclarativeNode
@@ -193,6 +199,7 @@ def declarative_node(klass, identifier, scope_key, store_locals):
     node = DeclarativeNode()
     node.klass = klass
     node.identifier = identifier
+    node.source_location = (filename, lineno)
     node.scope_key = scope_key
     node.store_locals = store_locals
     node.child_intercept = klass.__intercepts_child_nodes__
@@ -205,7 +212,7 @@ def declarative_node(klass, identifier, scope_key, store_locals):
     return node
 
 
-def enamldef_node(klass, identifier, scope_key, store_locals):
+def enamldef_node(klass, identifier, scope_key, store_locals, filename, lineno):
     """ Create and return an EnamlDefNode for the given class.
 
     Parameters
@@ -223,6 +230,12 @@ def enamldef_node(klass, identifier, scope_key, store_locals):
         Whether instances of the class should store the local scope in
         their storage map.
 
+    filename: str
+        The name of the file where the node is defined.
+
+    lineno: int
+        The line number within the file where the node is defined.
+
     Returns
     -------
     result : EnamlDefNode
@@ -231,6 +244,7 @@ def enamldef_node(klass, identifier, scope_key, store_locals):
     """
     node = EnamlDefNode()
     node.klass = klass
+    node.source_location = (filename, lineno)
     node.identifier = identifier
     node.scope_key = scope_key
     node.store_locals = store_locals

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -166,7 +166,7 @@ def add_storage(node, name, store_type, kind):
     setattr(klass, name, new)
 
 
-def declarative_node(klass, identifier, scope_key, store_locals, filename, lineno):
+def declarative_node(klass, identifier, scope_key, store_locals, source_location=None):
     """ Create and return a DeclarativeNode for the given klass.
 
     Parameters
@@ -184,11 +184,8 @@ def declarative_node(klass, identifier, scope_key, store_locals, filename, linen
         Whether instances of the class should store the local scope in
         their storage map.
 
-    filename: str
-        The name of the file where the node is defined.
-
-    lineno: int
-        The line number within the file where the node is defined.
+    source_location: tuple
+        A tuple of the filename and lineno where the node is defined.
 
     Returns
     -------
@@ -199,7 +196,7 @@ def declarative_node(klass, identifier, scope_key, store_locals, filename, linen
     node = DeclarativeNode()
     node.klass = klass
     node.identifier = identifier
-    node.source_location = (filename, lineno)
+    node.source_location = source_location
     node.scope_key = scope_key
     node.store_locals = store_locals
     node.child_intercept = klass.__intercepts_child_nodes__
@@ -212,7 +209,7 @@ def declarative_node(klass, identifier, scope_key, store_locals, filename, linen
     return node
 
 
-def enamldef_node(klass, identifier, scope_key, store_locals, filename, lineno):
+def enamldef_node(klass, identifier, scope_key, store_locals, source_location=None):
     """ Create and return an EnamlDefNode for the given class.
 
     Parameters
@@ -230,11 +227,8 @@ def enamldef_node(klass, identifier, scope_key, store_locals, filename, lineno):
         Whether instances of the class should store the local scope in
         their storage map.
 
-    filename: str
-        The name of the file where the node is defined.
-
-    lineno: int
-        The line number within the file where the node is defined.
+    source_location: tuple
+        A tuple of the filename and lineno where the node is defined.
 
     Returns
     -------
@@ -244,7 +238,7 @@ def enamldef_node(klass, identifier, scope_key, store_locals, filename, lineno):
     """
     node = EnamlDefNode()
     node.klass = klass
-    node.source_location = (filename, lineno)
+    node.source_location = source_location
     node.identifier = identifier
     node.scope_key = scope_key
     node.store_locals = store_locals
@@ -562,7 +556,7 @@ def bind_member(node, name, pair):
     node.engine.add_pair(name, pair)
 
 
-def run_operator(scope_node, node, name, op, code, f_globals):
+def run_operator(scope_node, node, name, op, code, f_globals, source_location=None):
     """ Run the operator for a given node.
 
     Parameters
@@ -586,12 +580,16 @@ def run_operator(scope_node, node, name, op, code, f_globals):
     f_globals : dict
         The globals dictionary to pass to the operator.
 
+    source_location: tuple
+        A tuple of the filename and lineno where the expression is defined.
+
     """
     operators = __get_operators()
     if op not in operators:
         raise TypeError("failed to load operator '%s'" % op)
     scope_key = scope_node.scope_key
     pair = operators[op](code, scope_key, f_globals)
+    pair.source_location = source_location
     if isinstance(name, tuple):
         # The template inst binding with a single name will take this
         # path by using a length-1 name tuple. See bug #78.

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -253,13 +253,16 @@ def enamldef_node(klass, identifier, scope_key, store_locals, source_location=No
     return node
 
 
-def template_node(scope_key):
+def template_node(scope_key, name: str = "template", source_location=None):
     """ Create and return a new template node.
 
     Parameters
     ----------
     scope_key : object
         The key for the local scope in the local storage maps.
+
+    source_location: tuple
+        A tuple of the filename and lineno where the node is defined.
 
     Returns
     -------
@@ -269,6 +272,8 @@ def template_node(scope_key):
     """
     node = TemplateNode()
     node.scope_key = scope_key
+    node.name = name
+    node.source_location = source_location
     return node
 
 

--- a/enaml/core/compiler_nodes.py
+++ b/enaml/core/compiler_nodes.py
@@ -87,8 +87,8 @@ class CompilerNode(Atom):
     """ A base class for defining compiler nodes.
 
     """
-    #: Location
-    source_location = Tuple()
+    #: The location in source code. A tuple of (filename, lineno).
+    source_location = Typed(tuple)
 
     #: The scope key for the for the local scope of the node.
     scope_key = Typed(object)

--- a/enaml/core/compiler_nodes.py
+++ b/enaml/core/compiler_nodes.py
@@ -10,8 +10,6 @@ from contextlib import contextmanager
 from atom.api import Atom, Bool, Str, Tuple, Typed, ForwardTyped
 from atom.datastructures.api import sortedmap
 
-from .expression_engine import ExpressionEngine
-
 
 #: The private stack of active local scopes.
 __stack = []
@@ -19,6 +17,12 @@ __stack = []
 
 #: The private map of active local scopes.
 __map = {}
+
+
+def expression_engine():
+    # Deferred import
+    from .expression_engine import ExpressionEngine
+    return ExpressionEngine
 
 
 @contextmanager
@@ -145,7 +149,7 @@ class DeclarativeNode(CompilerNode):
     child_intercept = Bool(False)
 
     #: The expression engine to associate with the instance.
-    engine = Typed(ExpressionEngine)
+    engine = ForwardTyped(expression_engine)
 
     #: The set of scope keys for the closure scopes. This will be None
     #: if the node does not require any closure scopes.
@@ -296,6 +300,9 @@ class TemplateNode(CompilerNode):
     #: provided by the compiler, and should be considered read-only.
     scope = Typed(sortedmap, ())
 
+    #: The name of the template
+    name = Str()
+
     def __call__(self, parent):
         """ Instantiate the type hierarchy.
 
@@ -354,6 +361,7 @@ class TemplateNode(CompilerNode):
         """
         node = super(TemplateNode, self).copy()
         node.scope = self.scope
+        node.name = self.name
         node.update_id_nodes()
         return node
 

--- a/enaml/core/compiler_nodes.py
+++ b/enaml/core/compiler_nodes.py
@@ -87,6 +87,9 @@ class CompilerNode(Atom):
     """ A base class for defining compiler nodes.
 
     """
+    #: Location
+    source_location = Tuple()
+
     #: The scope key for the for the local scope of the node.
     scope_key = Typed(object)
 
@@ -116,6 +119,7 @@ class CompilerNode(Atom):
         """
         node = type(self)()
         node.scope_key = self.scope_key
+        node.source_location = self.source_location
         node.children = [child.copy() for child in self.children]
         return node
 
@@ -187,6 +191,7 @@ class DeclarativeNode(CompilerNode):
             self.super_node(instance)
         f_locals = peek_scope()
         scope_key = self.scope_key
+        instance._d_node = self
         if self.identifier:
             f_locals[self.identifier] = instance
         if self.store_locals:

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -125,8 +125,8 @@ def find_pattern_node(node: "Declarative") -> Optional["Declarative"]:
     return None
 
 
-def find_template_node(node: "Declarative") -> tuple:
-    """ Find the template node which inserted the given node, if any.
+def find_template_inst_node(node: "Declarative") -> tuple:
+    """ Find the template instance node which inserted the given node, if any.
 
     Parameters
     ----------
@@ -180,17 +180,17 @@ def declarative_stack_summary(
         frame_summary = declarative_frame_summary(compiler_node, name)
         declarative_stack.append(frame_summary)
 
+        # When the compiler node is not in the parent compiler nodes
+        # children, the child was either inserted by a pattern node which
+        # intercepted children or inserted by a template.
         if parent is not None and compiler_node not in parent._d_node.children:
-            # When the compiler node is not in the parent compiler nodes
-            # children, the child was either inserted by a pattern node which
-            # intercepted children or inserted by a template.
             pattern_node = find_pattern_node(node)
             if pattern_node is not None:
                 node = pattern_node
                 continue
 
-            # Attempt to find the template which inserted the child
-            template_nodes = find_template_node(node)
+            # Attempt to find the template instance node
+            template_nodes = find_template_inst_node(node)
             if template_nodes is not None:
                 instance_node, template_node = template_nodes
                 template_frame = declarative_frame_summary(

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -169,7 +169,7 @@ def declarative_stack_summary(
         The stack summary.
 
     """
-    declarative_stack = []
+    declarative_stack = StackSummary()
     if expression is not None:
         declarative_stack.append(expression)
 
@@ -206,7 +206,7 @@ def declarative_stack_summary(
         node = parent
 
     declarative_stack.reverse()
-    return StackSummary.from_list(declarative_stack)
+    return declarative_stack
 
 
 class DeclarativeError(Exception):
@@ -230,12 +230,17 @@ class DeclarativeError(Exception):
 
 
         """
-        summary = self.summary = declarative_stack_summary(node, expression)
-        stack = "".join(summary.format())
+        self.summary = declarative_stack_summary(node, expression)
         self.error = exc
-        exc_type_name = exc.__class__.__name__
-        message = "\n{}{}: {}".format(stack, exc_type_name, exc)
-        super().__init__(message)
+        self._message = ""
+
+    def __str__(self):
+        if not self._message:
+            stack = "".join(self.summary.format())
+            exc = self.error
+            exc_type_name = exc.__class__.__name__
+            self._message = "\n{}{}: {}".format(stack, exc_type_name, exc)
+        return self._message
 
 
 def patch_d_member(member):

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -124,7 +124,8 @@ class DeclarativeError(Exception):
         self.summary = summary = declarative_stack_summary(node, expression)
         self.error = exc
         stack = ''.join(reversed(summary.format()))
-        super().__init__("\n{}".format(stack))
+        msg = "\n{}{}: {}".format(stack, exc.__class__.__name__, exc)
+        super().__init__(msg)
 
 
 def patch_d_member(member):

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+import linecache
+
 from atom.api import Atom, AtomMeta, ChangeType, DefaultValue, Member, Typed
 from traceback import StackSummary
 
@@ -99,14 +101,16 @@ def declarative_stack_summary(node) -> StackSummary:
         source = compiler_node.source_location
         if source is not None:
             filename, lineno = source
+            line = linecache.getline(filename, lineno)
         else:
             filename = ""
             lineno = -1
+            line = ""
         declarative_stack.append((
             filename,
             lineno,
             node.__class__.__name__,
-            "",  # TODO: get source
+            line,
         ))
         node = node.parent
     return StackSummary.from_list(declarative_stack)

--- a/enaml/core/enaml_ast.py
+++ b/enaml/core/enaml_ast.py
@@ -17,9 +17,6 @@ class ASTNode(Atom):
     #: The line number in the .enaml file which generated the node.
     lineno = Int(-1)
 
-    #: The filename where the node is defined.
-    filename = Str()
-
 
 class PragmaArg(Atom):
     """ An atom class which represents a pragma argument.

--- a/enaml/core/enaml_ast.py
+++ b/enaml/core/enaml_ast.py
@@ -17,6 +17,9 @@ class ASTNode(Atom):
     #: The line number in the .enaml file which generated the node.
     lineno = Int(-1)
 
+    #: The filename where the node is defined.
+    filename = Str()
+
 
 class PragmaArg(Atom):
     """ An atom class which represents a pragma argument.

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -123,9 +123,8 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg.load_const(node.identifier)
         cg.load_fast(cmn.SCOPE_KEY)
         cg.load_const(should_store)                 # helper -> class -> identifier -> bool
-        cg.load_const(node.filename)
-        cg.load_const(node.lineno)
-        cg.call_function(6)                         # node
+        cg.load_const((node.filename, node.lineno))
+        cg.call_function(5)                         # node
 
         # Store the node into the node list
         cmn.store_node(cg, index)

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -122,8 +122,8 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg.rot_two()
         cg.load_const(node.identifier)
         cg.load_fast(cmn.SCOPE_KEY)
-        cg.load_const(should_store)                 # helper -> class -> identifier -> bool
-        cg.load_const((cg.filename, node.lineno))
+        cg.load_const(should_store)
+        cg.load_const((cg.filename, node.lineno))   # helper -> class -> identifier -> bool -> location
         cg.call_function(5)                         # node
 
         # Store the node into the node list

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -123,7 +123,9 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg.load_const(node.identifier)
         cg.load_fast(cmn.SCOPE_KEY)
         cg.load_const(should_store)                 # helper -> class -> identifier -> bool
-        cg.call_function(4)                         # node
+        cg.load_const(node.filename)
+        cg.load_const(node.lineno)
+        cg.call_function(6)                         # node
 
         # Store the node into the node list
         cmn.store_node(cg, index)

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -123,7 +123,7 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg.load_const(node.identifier)
         cg.load_fast(cmn.SCOPE_KEY)
         cg.load_const(should_store)                 # helper -> class -> identifier -> bool
-        cg.load_const((node.filename, node.lineno))
+        cg.load_const((cg.filename, node.lineno))
         cg.call_function(5)                         # node
 
         # Store the node into the node list

--- a/enaml/core/expression_engine.py
+++ b/enaml/core/expression_engine.py
@@ -180,7 +180,16 @@ class ExpressionEngine(Atom):
         if handler is not None:
             pair = handler.read_pair
             if pair is not None:
-                return pair.reader(owner, name)
+                try:
+                    return pair.reader(owner, name)
+                except DeclarativeError:
+                    raise
+                except Exception as e:
+                    expression = None
+                    if pair.source_location:
+                        filename, lineno = pair.source_location
+                        expression = (filename, lineno, name)
+                    raise DeclarativeError(owner, e, expression) from e
         return NotImplemented
 
     def write(self, owner, name, change):

--- a/enaml/core/expression_engine.py
+++ b/enaml/core/expression_engine.py
@@ -259,7 +259,6 @@ class ExpressionEngine(Atom):
                             filename, lineno = pair.source_location
                             expression = (filename, lineno, name)
                         raise DeclarativeError(owner, e, expression) from e
-                        raise DeclarativeError(owner, e) from e
                     finally:
                         guards.remove(key)
 

--- a/enaml/core/expression_engine.py
+++ b/enaml/core/expression_engine.py
@@ -5,6 +5,8 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+from traceback import FrameSummary
+
 from atom.api import Atom, List, Typed
 from atom.datastructures.api import sortedmap
 from .declarative_meta import DeclarativeError
@@ -188,7 +190,9 @@ class ExpressionEngine(Atom):
                     expression = None
                     if pair.source_location:
                         filename, lineno = pair.source_location
-                        expression = (filename, lineno, name)
+                        expression = FrameSummary(
+                            filename, lineno, name, lookup_line=False
+                        )
                     raise DeclarativeError(owner, e, expression) from e
         return NotImplemented
 
@@ -227,7 +231,9 @@ class ExpressionEngine(Atom):
                         expression = None
                         if pair.source_location:
                             filename, lineno = pair.source_location
-                            expression = (filename, lineno, name)
+                            expression = FrameSummary(
+                                filename, lineno, name, lookup_line=False
+                            )
                         raise DeclarativeError(owner, e, expression) from e
                     finally:
                         guards.remove(key)
@@ -266,7 +272,9 @@ class ExpressionEngine(Atom):
                         expression = None
                         if pair.source_location:
                             filename, lineno = pair.source_location
-                            expression = (filename, lineno, name)
+                            expression = FrameSummary(
+                                filename, lineno, name, lookup_line=False
+                            )
                         raise DeclarativeError(owner, e, expression) from e
                     finally:
                         guards.remove(key)

--- a/enaml/core/template_compiler.py
+++ b/enaml/core/template_compiler.py
@@ -123,7 +123,9 @@ class FirstPassTemplateCompiler(block.FirstPassBlockCompiler):
         # Create the template compiler node and store in the node list.
         cmn.load_helper(cg, 'template_node')
         cg.load_fast(cmn.SCOPE_KEY)
-        cg.call_function(1)
+        cg.load_const(node.name)
+        cg.load_const((self.filename, node.lineno))
+        cg.call_function(3)
         cmn.store_node(cg, index)
 
         # Visit the body of the template.

--- a/enaml/widgets/toolkit_object.py
+++ b/enaml/widgets/toolkit_object.py
@@ -182,7 +182,6 @@ class ToolkitObject(Declarative):
         super(ToolkitObject, self).child_added(child)
         if isinstance(child, ToolkitObject) and self.proxy_is_active:
             try:
-                self.proxy.child_removed(child.proxy)
                 if not child.proxy_is_active:
                     child.activate_proxy()
                 self.proxy.child_added(child.proxy)

--- a/enaml/widgets/toolkit_object.py
+++ b/enaml/widgets/toolkit_object.py
@@ -186,7 +186,7 @@ class ToolkitObject(Declarative):
                     child.activate_proxy()
                 self.proxy.child_added(child.proxy)
             except DeclarativeError:
-                pass
+                raise
             except Exception as e:
                 raise DeclarativeError(child, e) from e
 
@@ -204,7 +204,7 @@ class ToolkitObject(Declarative):
             try:
                 self.proxy.child_removed(child.proxy)
             except DeclarativeError:
-                pass
+                raise
             except Exception as e:
                 raise DeclarativeError(child, e) from e
 
@@ -223,7 +223,7 @@ class ToolkitObject(Declarative):
                 try:
                     child.activate_proxy()
                 except DeclarativeError:
-                    pass
+                    raise
                 except Exception as e:
                     raise DeclarativeError(child, e) from e
         self.activate_bottom_up()

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -81,3 +81,30 @@ def test_error_during_event(enaml_qtbot):
     assert 'line 13, in MyWindow' in excinfo.exconly()
     assert 'line 17, in MyWidget' in excinfo.exconly()
     assert 'line 6, in PushButton' in excinfo.exconly()
+    assert 'line 7, in clicked' in excinfo.exconly()
+
+
+def test_error_during_manual_set(enaml_qtbot):
+    source = dedent("""\
+    from enaml.core.api import Looper
+    from enaml.widgets.api import Window, Container, Label
+
+    enamldef MyWindow(Window): main:
+        alias items: looper.iterable
+        Container:
+            Looper: looper:
+                iterable = []
+                Label:
+                    text = loop.item
+
+    """)
+    tester = compile_source(source, 'MyWindow')()
+    tester.show()
+    wait_for_window_displayed(enaml_qtbot, tester)
+    with pytest.raises(DeclarativeError) as excinfo:
+        tester.items = [False]  # not a stringiterable
+    print(excinfo.exconly())
+    assert 'line 4, in MyWindow' in excinfo.exconly()
+    assert 'line 6, in Container' in excinfo.exconly()
+    # Unfortunately Looper is not there...
+    assert 'line 9, in Label' in excinfo.exconly()

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -130,5 +130,5 @@ def test_error_during_manual_set(qt_app, qtbot):
         destroy_windows()
     assert 'line 4, in MyWindow' in excinfo.exconly()
     assert 'line 6, in Container' in excinfo.exconly()
-    # Unfortunately Looper is not there...
+    assert 'line 7, in Looper' in excinfo.exconly()
     assert 'line 9, in Label' in excinfo.exconly()

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -14,11 +14,8 @@ import pytest
 from enaml.core.declarative_meta import DeclarativeError
 from enaml.widgets.api import Window
 
-from utils import compile_source, wait_for_window_displayed, is_qt_available
+from utils import compile_source, wait_for_window_displayed
 
-
-pytestmark = pytest.mark.skipif(not is_qt_available(),
-                                reason='Requires a Qt binding')
 
 
 def destroy_windows():

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -74,7 +74,8 @@ def test_error_template_init(enaml_qtbot):
 
     assert 'line 11, in Main' in excinfo.exconly()
     # TODO: How can it determine the template name?
-    assert 'line 12, in template' in excinfo.exconly()
+    assert 'line 12, in Panel' in excinfo.exconly()
+    assert 'line 3, in Panel' in excinfo.exconly()
     assert 'line 4, in Container' in excinfo.exconly()
     assert 'line 5, in HtmlContent' in excinfo.exconly()
 

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -95,8 +95,7 @@ def test_error_during_manual_set(enaml_qtbot):
     tester.show()
     wait_for_window_displayed(enaml_qtbot, tester)
     with pytest.raises(DeclarativeError) as excinfo:
-        tester.items = [False]  # not a stringiterable
-    print(excinfo.exconly())
+        tester.items = [False]  # not a string iterable
     assert 'line 4, in MyWindow' in excinfo.exconly()
     assert 'line 6, in Container' in excinfo.exconly()
     # Unfortunately Looper is not there...

--- a/tests/core/test_declarative_error.py
+++ b/tests/core/test_declarative_error.py
@@ -13,10 +13,7 @@ import pytest
 
 from enaml.core.declarative_meta import DeclarativeError
 
-from utils import (
-    compile_source, wait_for_window_displayed, is_qt_available,
-    raises_error_signal
-)
+from utils import compile_source, wait_for_window_displayed, is_qt_available
 
 
 pytestmark = pytest.mark.skipif(not is_qt_available(),
@@ -44,7 +41,6 @@ def test_error_during_init(enaml_qtbot):
     assert 'line 6, in Conditional' in excinfo.exconly()
 
 
-@pytest.mark.qt_no_exception_capture
 def test_error_during_event(enaml_qtbot):
     from enaml.qt.QtCore import Qt, QObject, Signal
     source = dedent("""\
@@ -72,11 +68,8 @@ def test_error_during_event(enaml_qtbot):
     tester.show()
     wait_for_window_displayed(enaml_qtbot, tester)
 
-    with raises_error_signal(DeclarativeError, enaml_qtbot) as excinfo:
-        enaml_qtbot.mouseClick(
-            tester.widget.button.proxy.widget,
-            Qt.LeftButton
-        )
+    with pytest.raises(DeclarativeError) as excinfo:
+        tester.widget.button.clicked(True)
 
     assert 'line 13, in MyWindow' in excinfo.exconly()
     assert 'line 17, in MyWidget' in excinfo.exconly()


### PR DESCRIPTION
For #493 . It works by saving a reference to the compiler node to each declarative object and copies the filename and line number during compilation. 

Unfortunately this breaks any existing caches because of the additional parameters, I'm not sure what to do about that, it could maybe provide empty defaults for the filename and lineno?

Also it currently doesn't catch errors when manually updating an expression, eg so I'm not sure if it should be doing a try/except in the expression engine itself.