### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/examples/ex_grid.rst
+++ b/docs/source/examples/ex_grid.rst
@@ -16,7 +16,7 @@ spacers to arrange things nicely.
 
 The ``grid`` function allows items to span multiple cells by assigning the
 same item to multiple cells. No checks are performed to ensure an item
-spans a continugous cell block. Instead, items will span the smallest
+spans a contiguous cell block. Instead, items will span the smallest
 rectangular cell block which encloses all of its locations. Empty cells
 are defined by using ``None`` as the cell item.
 

--- a/enaml/qt/q_popup_view.py
+++ b/enaml/qt/q_popup_view.py
@@ -398,7 +398,7 @@ def adjust_arrow_rect(screen, rect, arrow_edge, target_pos, offset):
 
 
 class QPopupView(QWidget):
-    """ A custom QWidget which implements a framless popup widget.
+    """ A custom QWidget which implements a frameless popup widget.
 
     It is useful for showing transient configuration dialogs as well
     as temporary notification windows.

--- a/enaml/qt/qt_action.py
+++ b/enaml/qt/qt_action.py
@@ -107,7 +107,7 @@ class QtAction(QtToolkitObject, ProxyAction):
         self.widget.setToolTip(tool_tip)
 
     def set_status_tip(self, status_tip):
-        """ Set the status tip on the underyling control.
+        """ Set the status tip on the underlying control.
 
         """
         self.widget.setStatusTip(status_tip)

--- a/enaml/qt/qt_dock_area.py
+++ b/enaml/qt/qt_dock_area.py
@@ -229,7 +229,7 @@ class QtDockArea(QtConstraintsWidget, ProxyDockArea):
     # ProxyDockArea API
     #--------------------------------------------------------------------------
     def set_tab_position(self, position):
-        """ Set the default tab position on the underyling widget.
+        """ Set the default tab position on the underlying widget.
 
         """
         self.widget.setTabPosition(TAB_POSITIONS[position])

--- a/enaml/qt/qt_dock_item.py
+++ b/enaml/qt/qt_dock_item.py
@@ -103,7 +103,7 @@ class QtDockItem(QtWidget, ProxyDockItem):
         self.set_closable(d.closable)
 
     def init_layout(self):
-        """ Initialize the layout for the underyling widget.
+        """ Initialize the layout for the underlying widget.
 
         """
         super(QtDockItem, self).init_layout()

--- a/enaml/qt/qt_dock_pane.py
+++ b/enaml/qt/qt_dock_pane.py
@@ -294,7 +294,7 @@ class QtDockPane(QtWidget, ProxyDockPane):
         self.widget.setTitleBarVisible(visible)
 
     def set_title_bar_orientation(self, orientation):
-        """ Set the title bar orientation of the underyling widget.
+        """ Set the title bar orientation of the underlying widget.
 
         """
         widget = self.widget

--- a/enaml/qt/qt_flow_area.py
+++ b/enaml/qt/qt_flow_area.py
@@ -169,7 +169,7 @@ class QtFlowArea(QtFrame, ProxyFlowArea):
         self.widget.layout().setAlignment(_ALIGN_MAP[align])
 
     def set_horizontal_spacing(self, spacing):
-        """ Set the horizontal spacing of the underyling control.
+        """ Set the horizontal spacing of the underlying control.
 
         """
         self.widget.layout().setHorizontalSpacing(spacing)

--- a/enaml/qt/qt_flow_item.py
+++ b/enaml/qt/qt_flow_item.py
@@ -236,7 +236,7 @@ class QtFlowItem(QtWidget, ProxyFlowItem):
         self.set_ortho_stretch(d.ortho_stretch)
 
     def init_layout(self):
-        """ Initialize the layout for the underyling widget.
+        """ Initialize the layout for the underlying widget.
 
         """
         super(QtFlowItem, self).init_layout()

--- a/enaml/qt/qt_notebook.py
+++ b/enaml/qt/qt_notebook.py
@@ -393,7 +393,7 @@ class QtNotebook(QtConstraintsWidget, ProxyNotebook):
         self.widget = widget
 
     def init_widget(self):
-        """ Initialize the underyling widget.
+        """ Initialize the underlying widget.
 
         """
         super(QtNotebook, self).init_widget()

--- a/enaml/qt/qt_page.py
+++ b/enaml/qt/qt_page.py
@@ -312,7 +312,7 @@ class QtPage(QtWidget, ProxyPage):
         self.widget.pageClosed.connect(self.on_page_closed)
 
     def init_layout(self):
-        """ Initialize the layout for the underyling widget.
+        """ Initialize the layout for the underlying widget.
 
         """
         super(QtPage, self).init_layout()

--- a/enaml/qt/qt_split_item.py
+++ b/enaml/qt/qt_split_item.py
@@ -132,7 +132,7 @@ class QtSplitItem(QtWidget, ProxySplitItem):
         self.widget = QSplitItem(self.parent_widget())
 
     def init_widget(self):
-        """ Initialize the underyling widget.
+        """ Initialize the underlying widget.
 
         """
         super(QtSplitItem, self).init_widget()
@@ -141,7 +141,7 @@ class QtSplitItem(QtWidget, ProxySplitItem):
         self.set_collapsible(d.collapsible)
 
     def init_layout(self):
-        """ Initialize the layout for the underyling widget.
+        """ Initialize the layout for the underlying widget.
 
         """
         super(QtSplitItem, self).init_layout()

--- a/enaml/qt/qt_stack_item.py
+++ b/enaml/qt/qt_stack_item.py
@@ -75,7 +75,7 @@ class QtStackItem(QtWidget, ProxyStackItem):
         self.widget = QStackItem(self.parent_widget())
 
     def init_layout(self):
-        """ Initialize the layout for the underyling widget.
+        """ Initialize the layout for the underlying widget.
 
         """
         super(QtStackItem, self).init_layout()

--- a/enaml/qt/qt_tool_bar.py
+++ b/enaml/qt/qt_tool_bar.py
@@ -339,7 +339,7 @@ class QtToolBar(QtConstraintsWidget, ProxyToolBar):
                 self._guard &= ~FLOATED_GUARD
 
     def set_dock_area(self, dock_area):
-        """ Set the dock area on the underyling widget.
+        """ Set the dock area on the underlying widget.
 
         """
         self.widget.setToolBarArea(DOCK_AREAS[dock_area])

--- a/enaml/styling.py
+++ b/enaml/styling.py
@@ -325,7 +325,7 @@ class Stylable(Declarative):
     def parent_changed(self, old, new):
         """ A reimplemented parent changed event handler.
 
-        This will notifiy the :class:`StyleCache` if the parent of
+        This will notify the :class:`StyleCache` if the parent of
         the item has changed.
 
         """

--- a/enaml/widgets/mpl_canvas.py
+++ b/enaml/widgets/mpl_canvas.py
@@ -13,7 +13,7 @@ from .control import Control, ProxyControl
 
 
 #: Delay the import of matplotlib until needed. This removes the hard
-#: dependecy on matplotlib for the rest of the Enaml code base.
+#: dependency on matplotlib for the rest of the Enaml code base.
 def Figure():
     from matplotlib.figure import Figure
     return Figure

--- a/enaml/widgets/vtk_canvas.py
+++ b/enaml/widgets/vtk_canvas.py
@@ -12,7 +12,7 @@ from enaml.core.declarative import d_, observe
 from .control import Control, ProxyControl
 
 
-#: Delay the import of vtk until needed. This removes the hard dependecy
+#: Delay the import of vtk until needed. This removes the hard dependency
 #: on vtk for the rest of the Enaml code base.
 def vtkRenderer():
     from vtk import vtkRenderer

--- a/examples/workbench/crash_course.rst
+++ b/examples/workbench/crash_course.rst
@@ -212,7 +212,7 @@ The `Plugin` class can be imported from `enaml.workbench.api`.
 
 It will be uncommon for most end-user developers to ever need to create a
 custom plugin class. That job is reserved for core application developers
-which actually define how the application can be extened. That said, there
+which actually define how the application can be extended. That said, there
 are two methods on a plugin which will be of interest to developers:
 
 start


### PR DESCRIPTION
There are small typos in:
- docs/source/examples/ex_grid.rst
- enaml/qt/q_popup_view.py
- enaml/qt/qt_action.py
- enaml/qt/qt_dock_area.py
- enaml/qt/qt_dock_item.py
- enaml/qt/qt_dock_pane.py
- enaml/qt/qt_flow_area.py
- enaml/qt/qt_flow_item.py
- enaml/qt/qt_notebook.py
- enaml/qt/qt_page.py
- enaml/qt/qt_split_item.py
- enaml/qt/qt_stack_item.py
- enaml/qt/qt_tool_bar.py
- enaml/styling.py
- enaml/widgets/mpl_canvas.py
- enaml/widgets/vtk_canvas.py
- examples/workbench/crash_course.rst

Fixes:
- Should read `underlying` rather than `underyling`.
- Should read `dependency` rather than `dependecy`.
- Should read `notify` rather than `notifiy`.
- Should read `frameless` rather than `framless`.
- Should read `extended` rather than `extened`.
- Should read `contiguous` rather than `continugous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md