### PR TITLE
Workaround multi-display issues on X11 with popups

### DIFF
--- a/enaml/qt/q_popup_view.py
+++ b/enaml/qt/q_popup_view.py
@@ -833,11 +833,21 @@ class QPopupView(QWidget):
         """ Access the screen on which this popup is displayed.
 
         """
-        window = self.windowHandle()
-        if window is None:
-            window = QApplication.primaryScreen()
+        screen = None
+        parent = self.parent()
+        if parent:
+            if parent.isWindow():
+                screen = parent.screen()
+            else:
+                screen = parent.window().screen()
+        else:
+            window = self.windowHandle()
+            if window:
+                screen = window.screen()
+        if screen is None:
+            screen = QApplication.primaryScreen()
 
-        return window.screen()
+        return screen
 
     def _refreshGeometry(self, force=False):
         """ Refresh the geometry for the popup using the current state.


### PR DESCRIPTION
For #499. This disables the on screen checks to fix weird positioning of popups on X11 when multiple displays are present. Tested with QT 5.15 and 6.3.1 with 2 and 3 FHD monitors in a horizontal row.

The desktop notification of the popup example is still showing on the primary desktop.  

If anyone else is able to test it would be appreciated.