### PR TITLE
Prepare release 0.15.2

### DIFF
--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 from functools import update_wrapper
 
-from atom.api import Event, Instance, Member, add_member
+from atom.api import Event, Instance, Member
 from atom.datastructures.api import sortedmap
 
 from .alias import Alias
@@ -154,8 +154,16 @@ def add_storage(node, name, store_type, kind):
     else:
         raise RuntimeError("invalid kind '%s'" % kind)
 
+    if member is not None:
+        new.set_index(member.index)
+        new.copy_static_observers(member)
+    else:
+        new.set_index(len(members))
+
+    new.set_name(name)
     patch_d_member(new)
-    add_member(klass, name, new)
+    members[name] = new
+    setattr(klass, name, new)
 
 
 def declarative_node(klass, identifier, scope_key, store_locals):

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,7 +3,7 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
-0.15.2 - unreleased
+0.15.2 - 19/08/2022
 -------------------
 - fix position of popup view when multiple displays are used PR #500
 - reimplement DockArea.initialize instead of shadowing the initialized member.

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -5,12 +5,13 @@ Dates are written as DD/MM/YYYY
 
 0.15.2 - unreleased
 -------------------
+- fix position of popup view when multiple displays are used PR #500
 - reimplement DockArea.initialize instead of shadowing the initialized member.
   PR #502
 - require qtpy>=2.1 far Qt backends version PR #501
 - qt: use QEvent.Type to coerce new registered event type with all bindings. PR #497
   This requires PyQt 6.3.1 to work and allow to eliminate a deprecation warning.
-
+- fix loading of dock area guide images. PR #503
 
 0.15.1 - 13/06/2022
 -------------------


### PR DESCRIPTION
I reverted d47be167 that requires the development branch of atom which is not ready for a new release.