### PR TITLE
Add python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         qt-version: [5, 6]
         qt-binding: [pyqt, pyside]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11.2']
         qt-version: [5, 6]
         qt-binding: [pyqt, pyside]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
             qt-binding: pyside
           - python-version: '3.11.2 - 3.12'
             qt-version: 5
-            qt-binding: pyside
           - python-version: '3.8'
             qt-version: 6
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '>=3.11.2 - 3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11.2 - 3.12']
         qt-version: [5, 6]
         qt-binding: [pyqt, pyside]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '>=3.11.2 - 3.12']
         qt-version: [5, 6]
         qt-binding: [pyqt, pyside]
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11.2']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         qt-version: [5, 6]
         qt-binding: [pyqt, pyside]
         exclude:
           - python-version: '3.10'
+            qt-version: 5
+            qt-binding: pyside
+          - python-version: '3.11'
             qt-version: 5
             qt-binding: pyside
           - python-version: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - python-version: '3.10'
             qt-version: 5
             qt-binding: pyside
-          - python-version: '3.11'
+          - python-version: '3.11.2 - 3.12'
             qt-version: 5
             qt-binding: pyside
           - python-version: '3.8'

--- a/LICENSE
+++ b/LICENSE
@@ -88,7 +88,7 @@ With this in mind, the following banner should be used in any source code file
 to indicate the copyright and license terms:
 
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ main_doc = 'index'
 
 # General information about the project.
 project = 'Enaml'
-copyright = '2013-2021, Nucleic Development Team'
+copyright = '2013-2023, Nucleic Development Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -292,7 +292,7 @@ man_pages = [
 epub_title = 'Enaml'
 epub_author = 'Chris Colbert'
 epub_publisher = 'Nucleic Development Team'
-epub_copyright = '2013-2022, Nucleic Development Team'
+epub_copyright = '2013-2023, Nucleic Development Team'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -16,6 +16,8 @@ PY39 = sys.version_info >= (3, 9)
 
 PY310 = sys.version_info >= (3, 10)
 
+PY311 = sys.version_info >= (3, 11)
+
 # Functions used to update the co_filename slot of a code object
 # Available in Python 3.5+ (tested up to 3.8)
 from _imp import _fix_co_filename

--- a/enaml/core/block_compiler.py
+++ b/enaml/core/block_compiler.py
@@ -8,6 +8,7 @@
 from atom.api import Typed
 
 from . import compiler_common as cmn
+from ..compat import PY311
 
 
 class BaseBlockCompiler(cmn.CompilerBase):
@@ -136,6 +137,8 @@ class SecondPassBlockCompiler(BaseBlockCompiler):
             # Create the unpack map.
             cg = self.code_generator
             index = self.index_map[node]
+            if PY311:
+                cg.push_null()
             cmn.load_helper(cg, 'make_unpack_map')
             cmn.load_node(cg, index)
             cg.call_function(1)

--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -323,14 +323,14 @@ class CodeGenerator(Atom):
             bc.Instr("LOAD_BUILD_CLASS"),               # TOS -> builtins.__build_class__
         )
 
-    def make_function(self, n_defaults=0, name=None):
+    def make_function(self, flags=0, name=None):
         """ Make a function from a code object on the TOS.
 
         """
         if not PY311:
             self.load_const(name)
         self.code_ops.append(                           # TOS -> qual_name -> code -> defaults
-            bc.Instr("MAKE_FUNCTION", n_defaults),      # TOS -> func
+            bc.Instr("MAKE_FUNCTION", flags),           # TOS -> func
         )
 
     def push_null(self):

--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -525,7 +525,8 @@ class CodeGenerator(Atom):
             last_block = cfg[-1]
             for block in list(cfg):
                 if (
-                    block[-1].name == "RETURN_VALUE"
+                    isinstance(block[-1], bc.Instr)
+                    and block[-1].name == "RETURN_VALUE"
                     and block[-2].name == "LOAD_CONST"
                     and block[-2].arg is None
                     and block[-1].lineno not in _inspector.lines

--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2019, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -8,6 +8,7 @@
 from types import CodeType
 
 import bytecode as bc
+from ..compat import PY311
 
 
 class CodeTracer(object):
@@ -224,6 +225,130 @@ class CodeInverter(object):
         self.fail()
 
 
+if PY311:
+    def call_tracer_load_attr(tracer_op: str, i_arg: int, Instr=bc.Instr):
+        return [                                # obj
+            Instr("PUSH_NULL"),                 # obj -> null
+            Instr(tracer_op, '_[tracer]'),      # obj -> null -> tracer
+            Instr("LOAD_ATTR", 'load_attr'),    # obj -> null -> tracefunc
+            Instr("COPY", 3),                   # obj -> null -> tracefunc -> obj
+            Instr("LOAD_CONST", i_arg),         # obj -> null -> tracefunc -> obj -> attr
+            Instr("PRECALL", 0x0002),
+            Instr("CALL", 0x0002),              # obj -> retval
+            Instr("POP_TOP"),                   # obj
+        ]
+
+    def call_tracer_call_function(tracer_op: str, i_arg: int, Instr=bc.Instr):
+        # n_stack_args = i_arg
+        return [                                      # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+            Instr("BUILD_TUPLE", i_arg),              # func -> argtuple
+            Instr("PUSH_NULL"),                       # func -> argtuple -> null
+            Instr(tracer_op, '_[tracer]'),            # func -> argtuple -> null -> tracer
+            Instr("LOAD_ATTR", 'call_function'),      # func -> argtuple -> null -> tracefunc
+            Instr("COPY", 4),                         # func -> argtuple -> null -> tracefunc -> func
+            Instr("COPY", 4),                         # func -> argtuple -> null -> tracefunc -> func -> argtuple
+            Instr("LOAD_CONST", i_arg),               # func -> argtuple -> null -> tracefunc -> func -> argtuple -> argspec
+            Instr("PRECALL", 0x0003),
+            Instr("CALL", 0x0003),                    # func -> argtuple -> retval
+            Instr("POP_TOP"),                         # func -> argtuple
+            Instr("UNPACK_SEQUENCE", i_arg),          # func -> arg(n-1) -> arg(n-2) -> ... -> arg(0)
+            Instr("BUILD_TUPLE", i_arg),              # func -> reversedargtuple
+            Instr("UNPACK_SEQUENCE", i_arg),          # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+        ]
+
+    def call_tracer_binary_subscr(tracer_op: str, Instr=bc.Instr):
+        return [                                  # obj -> idx
+            Instr("PUSH_NULL"),                   # obj -> idx -> null
+            Instr(tracer_op, '_[tracer]'),        # obj -> idx -> null -> tracer
+            Instr("LOAD_ATTR", 'binary_subscr'),  # obj -> idx -> null -> tracefunc
+            Instr("COPY", 4),                     # obj -> idx -> null -> tracefunc -> obj
+            Instr("COPY", 4),                     # obj -> idx -> null -> tracefunc -> obj -> idx
+            Instr("PRECALL", 0x0002),
+            Instr("CALL", 0x0002),                # obj -> idx -> retval
+            Instr("POP_TOP"),                     # obj -> idx
+        ]
+
+    def call_tracer_get_iter(tracer_op: str, Instr=bc.Instr):
+        return [                             # obj
+            Instr("PUSH_NULL"),              # obj -> null
+            Instr(tracer_op, '_[tracer]'),   # obj -> null -> tracer
+            Instr("LOAD_ATTR", 'get_iter'),  # obj -> null -> tracefunc
+            Instr("COPY", 3),                # obj -> null -> tracefunc -> obj
+            Instr("PRECALL", 0x0001),
+            Instr("CALL", 0x0001),           # obj -> retval
+            Instr("POP_TOP"),                # obj
+        ]
+
+    def call_tracer_return_value(tracer_op: str, Instr=bc.Instr):
+        return [
+            Instr("PUSH_NULL"),                  # obj -> null
+            Instr(tracer_op, '_[tracer]'),       # obj -> null -> tracer
+            Instr("LOAD_ATTR", 'return_value'),  # obj -> null -> tracefunc
+            Instr("COPY", 3),                    # obj -> null -> tracefunc -> obj
+            Instr("PRECALL", 0x0001),
+            Instr("CALL", 0x0001),               # obj -> retval
+            Instr("POP_TOP"),                    # obj
+        ]
+
+else:
+    def call_tracer_load_attr(tracer_op: str, i_arg: int, Instr=bc.Instr):
+        return [                                # obj
+            Instr("DUP_TOP"),                   # obj -> obj
+            Instr(tracer_op, '_[tracer]'),      # obj -> obj -> tracer
+            Instr("LOAD_ATTR", 'load_attr'),    # obj -> obj -> tracefunc
+            Instr("ROT_TWO"),                   # obj -> tracefunc -> obj
+            Instr("LOAD_CONST", i_arg),         # obj -> tracefunc -> obj -> attr
+            Instr("CALL_FUNCTION", 0x0002),     # obj -> retval
+            Instr("POP_TOP"),                   # obj
+        ]
+
+    def call_tracer_call_function(tracer_op: str, i_arg: int, Instr=bc.Instr):
+        # n_stack_args = i_arg
+        return [                                      # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+            Instr("BUILD_TUPLE", i_arg),              # func -> argtuple
+            Instr("DUP_TOP_TWO"),                     # func -> argtuple -> func -> argtuple
+            Instr(tracer_op, '_[tracer]'),            # func -> argtuple -> func -> argtuple -> tracer
+            Instr("LOAD_ATTR", 'call_function'),      # func -> argtuple -> func -> argtuple -> tracefunc
+            Instr("ROT_THREE"),                       # func -> argtuple -> tracefunc -> func -> argtuple
+            Instr("LOAD_CONST", i_arg),               # func -> argtuple -> tracefunc -> func -> argtuple -> argspec
+            Instr("CALL_FUNCTION", 0x0003),           # func -> argtuple -> retval
+            Instr("POP_TOP"),                         # func -> argtuple
+            Instr("UNPACK_SEQUENCE", i_arg),          # func -> arg(n-1) -> arg(n-2) -> ... -> arg(0)
+            Instr("BUILD_TUPLE", i_arg),              # func -> reversedargtuple
+            Instr("UNPACK_SEQUENCE", i_arg),          # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+        ]
+
+    def call_tracer_binary_subscr(tracer_op: str, Instr=bc.Instr):
+        return [                                  # obj -> idx
+            Instr("DUP_TOP_TWO"),                 # obj -> idx -> obj -> idx
+            Instr(tracer_op, '_[tracer]'),        # obj -> idx -> obj -> idx -> tracer
+            Instr("LOAD_ATTR", 'binary_subscr'),  # obj -> idx -> obj -> idx -> tracefunc
+            Instr("ROT_THREE"),                   # obj -> idx -> tracefunc -> obj -> idx
+            Instr("CALL_FUNCTION", 0x0002),       # obj -> idx -> retval
+            Instr("POP_TOP"),                     # obj -> idx
+        ]
+
+    def call_tracer_get_iter(tracer_op: str, Instr=bc.Instr):
+        return [                             # obj
+            Instr("DUP_TOP"),                # obj -> obj
+            Instr(tracer_op, '_[tracer]'),   # obj -> obj -> tracer
+            Instr("LOAD_ATTR", 'get_iter'),  # obj -> obj -> tracefunc
+            Instr("ROT_TWO"),                # obj -> tracefunc -> obj
+            Instr("CALL_FUNCTION", 0x0001),  # obj -> retval
+            Instr("POP_TOP"),                # obj
+        ]
+
+    def call_tracer_return_value(tracer_op: str, Instr=bc.Instr):
+        return [                                 # obj
+            Instr("DUP_TOP"),                    # obj -> obj
+            Instr(tracer_op, '_[tracer]'),       # obj -> obj -> tracer
+            Instr("LOAD_ATTR", 'return_value'),  # obj -> obj -> tracefunc
+            Instr("ROT_TWO"),                    # obj -> tracefunc -> obj
+            Instr("CALL_FUNCTION", 0x0001),      # obj -> retval
+            Instr("POP_TOP"),                    # obj
+        ]
+
+
 def inject_tracing(bytecode, nested=False):
     """ Inject tracing code into the given code list.
 
@@ -258,78 +383,35 @@ def inject_tracing(bytecode, nested=False):
     # that the tracer has no visible side effects, the tracing is
     # transparent.
     inserts = {}
+    i_name = None
     for idx, instr in enumerate(bytecode):
         # Filter out SetLineno and Label
         if not isinstance(instr, bc.Instr):
             continue
+        last_i_name = i_name
         i_name = instr.name
         i_arg = instr.arg
         if i_name == "LOAD_ATTR":
-            tracing_code = [                           # obj
-                bc.Instr("DUP_TOP"),                   # obj -> obj
-                bc.Instr(tracer_op, '_[tracer]'),      # obj -> obj -> tracer
-                bc.Instr("LOAD_ATTR", 'load_attr'),    # obj -> obj -> tracefunc
-                bc.Instr("ROT_TWO"),                   # obj -> tracefunc -> obj
-                bc.Instr("LOAD_CONST", i_arg),         # obj -> tracefunc -> obj -> attr
-                bc.Instr("CALL_FUNCTION", 0x0002),     # obj -> retval
-                bc.Instr("POP_TOP"),                   # obj
-            ]
-            inserts[idx] = tracing_code
-        elif i_name == "CALL_FUNCTION":
-            # From Python 3.6, CALL_FUNCTION is only used for positional
-            # arguments and the argument is directly the number of arguments
-            # on the stack.
-            n_stack_args = i_arg
-            tracing_code = [                                         # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-                bc.Instr("BUILD_TUPLE", n_stack_args),       # func -> argtuple
-                bc.Instr("DUP_TOP_TWO"),                     # func -> argtuple -> func -> argtuple
-                bc.Instr(tracer_op, '_[tracer]'),            # func -> argtuple -> func -> argtuple -> tracer
-                bc.Instr("LOAD_ATTR", 'call_function'),      # func -> argtuple -> func -> argtuple -> tracefunc
-                bc.Instr("ROT_THREE"),                       # func -> argtuple -> tracefunc -> func -> argtuple
-                bc.Instr("LOAD_CONST", i_arg),               # func -> argtuple -> tracefunc -> func -> argtuple -> argspec
-                bc.Instr("CALL_FUNCTION", 0x0003),           # func -> argtuple -> retval
-                bc.Instr("POP_TOP"),                         # func -> argtuple
-                bc.Instr("UNPACK_SEQUENCE", n_stack_args),   # func -> arg(n-1) -> arg(n-2) -> ... -> arg(0)
-                bc.Instr("BUILD_TUPLE", n_stack_args),       # func -> reversedargtuple
-                bc.Instr("UNPACK_SEQUENCE", n_stack_args),   # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-            ]
-            inserts[idx] = tracing_code
-
+            inserts[idx] = call_tracer_load_attr(tracer_op, i_arg)
         # We do not trace CALL_FUNCTION_KW and CALL_FUNCTION_EX since
         # tracing and inverting only require to detect getattr and setattr
         # both in this project and in traits-enaml. Those two are always called
         # using the CALL_FUNCTION bytecode instruction.
-
+        elif i_name == "CALL_FUNCTION":
+            # From Python 3.6, CALL_FUNCTION is only used for positional
+            # arguments and the argument is directly the number of arguments
+            # on the stack.
+            inserts[idx] = call_tracer_call_function(tracer_op, i_arg)
+        elif i_name == "PRECALL" and last_i_name != "KW_NAMES":
+            # On Python 3.11, CALL is preceeded with a PRECALL
+            # Skip, if the last instruction was a KW_NAMES
+            inserts[idx] = call_tracer_call_function(tracer_op, i_arg)
         elif i_name == "BINARY_SUBSCR":
-            tracing_code = [                                     # obj -> idx
-                bc.Instr("DUP_TOP_TWO"),                 # obj -> idx -> obj -> idx
-                bc.Instr(tracer_op, '_[tracer]'),        # obj -> idx -> obj -> idx -> tracer
-                bc.Instr("LOAD_ATTR", 'binary_subscr'),  # obj -> idx -> obj -> idx -> tracefunc
-                bc.Instr("ROT_THREE"),                   # obj -> idx -> tracefunc -> obj -> idx
-                bc.Instr("CALL_FUNCTION", 0x0002),       # obj -> idx -> retval
-                bc.Instr("POP_TOP"),                     # obj -> idx
-            ]
-            inserts[idx] = tracing_code
+            inserts[idx] = call_tracer_binary_subscr(tracer_op)
         elif i_name == "GET_ITER":
-            tracing_code = [                               # obj
-                bc.Instr("DUP_TOP"),               # obj -> obj
-                bc.Instr(tracer_op, '_[tracer]'),  # obj -> obj -> tracer
-                bc.Instr("LOAD_ATTR", 'get_iter'), # obj -> obj -> tracefunc
-                bc.Instr("ROT_TWO"),               # obj -> tracefunc -> obj
-                bc.Instr("CALL_FUNCTION", 0x0001), # obj -> retval
-                bc.Instr("POP_TOP"),               # obj
-            ]
-            inserts[idx] = tracing_code
+            inserts[idx] = call_tracer_get_iter(tracer_op)
         elif i_name == "RETURN_VALUE":
-            tracing_code = [
-                bc.Instr("DUP_TOP"),                   # obj
-                bc.Instr(tracer_op, '_[tracer]'),      # obj -> obj -> tracer
-                bc.Instr("LOAD_ATTR", 'return_value'), # obj -> obj -> tracefunc
-                bc.Instr("ROT_TWO"),                   # obj -> tracefunc -> obj
-                bc.Instr("CALL_FUNCTION", 0x0001),     # obj -> retval
-                bc.Instr("POP_TOP"),                   # obj
-            ]
-            inserts[idx] = tracing_code
+            inserts[idx] = call_tracer_return_value(tracer_op)
         elif isinstance(i_arg, CodeType):
             # Inject tracing in nested code object if they use their parent
             # locals.
@@ -347,6 +429,107 @@ def inject_tracing(bytecode, nested=False):
         new_code.append(code_op)
 
     return new_code
+
+
+if PY311:
+    def call_inverter_load_name(i_arg: int, Instr=bc.Instr):
+        return [
+            Instr("PUSH_NULL"),                    # null -> inverter
+            Instr("LOAD_FAST", '_[inverter]'),     # null -> inverter
+            Instr("LOAD_ATTR", 'load_name'),       # null -> invertfunc
+            Instr("LOAD_CONST", i_arg),            # null -> invertfunc -> name
+            Instr("LOAD_FAST", '_[value]'),        # null -> invertfunc -> name - > value
+            Instr("PRECALL", 0x0002),
+            Instr("CALL", 0x0002),                 # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_load_attr(i_arg: int, Instr=bc.Instr):
+        return [                                   # obj
+            Instr("PUSH_NULL"),                    # obj -> null
+            Instr("SWAP", 2),                      # null -> obj
+            Instr("LOAD_FAST", '_[inverter]'),     # null -> obj -> inverter
+            Instr("LOAD_ATTR", 'load_attr'),       # null -> obj -> invertfunc
+            Instr("SWAP", 2),                      # null -> invertfunc -> obj
+            Instr("LOAD_CONST", i_arg),            # null -> invertfunc -> obj -> attr
+            Instr("LOAD_FAST", '_[value]'),        # null -> invertfunc -> obj -> attr -> value
+            Instr("PRECALL", 0x0003),              #
+            Instr("CALL", 0x0003),                 # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_call_function(i_arg: int, Instr=bc.Instr):
+        # n_stack_args = i_arg
+        return [                                   # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+            Instr("BUILD_TUPLE", i_arg),           # func -> argtuple
+            Instr("PUSH_NULL"),                    # func -> argtuple -> null
+            Instr("SWAP", 3),                      # null -> argtuple -> func
+            Instr("LOAD_FAST", '_[inverter]'),     # null -> argtuple -> func -> inverter
+            Instr("LOAD_ATTR", 'call_function'),   # null -> argtuple -> func -> invertfunc
+            Instr("SWAP", 3),                      # null -> invertfunc -> func -> argtuple
+            Instr("LOAD_CONST", i_arg),            # null -> invertfunc -> func -> argtuple -> argspec
+            Instr("LOAD_FAST", '_[value]'),        # null -> invertfunc -> func -> argtuple -> argspec -> value
+            Instr("PRECALL", 0x0004),
+            Instr("CALL", 0x0004),                 # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_binary_subsrc(Instr=bc.Instr):
+        return [                                   # obj -> index
+            Instr("PUSH_NULL"),                    # obj -> index -> null
+            Instr("SWAP", 3),                      # null -> index -> obj
+            Instr("LOAD_FAST", '_[inverter]'),     # null -> index -> obj -> inverter
+            Instr("LOAD_ATTR", 'binary_subscr'),   # null -> index -> obj -> invertfunc
+            Instr("SWAP", 3),                      # null -> invertfunc -> obj -> index
+            Instr("LOAD_FAST", '_[value]'),        # null -> invertfunc -> obj -> index -> value
+            Instr("PRECALL", 0x0003),              #
+            Instr("CALL", 0x0003),                 # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+else:
+    def call_inverter_load_name(i_arg: int, Instr=bc.Instr):
+        return [
+            Instr("LOAD_FAST", '_[inverter]'),     # inverter
+            Instr("LOAD_ATTR", 'load_name'),       # invertfunc
+            Instr("LOAD_CONST", i_arg),            # invertfunc -> name
+            Instr("LOAD_FAST", '_[value]'),        # invertfunc -> name - > value
+            Instr("CALL_FUNCTION", 0x0002),        # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_load_attr(i_arg: int, Instr=bc.Instr):
+        return [                                   # obj
+            Instr("LOAD_FAST", '_[inverter]'),     # obj -> inverter
+            Instr("LOAD_ATTR", 'load_attr'),       # obj -> invertfunc
+            Instr("ROT_TWO"),                      # invertfunc -> obj
+            Instr("LOAD_CONST", i_arg),            # invertfunc -> obj -> attr
+            Instr("LOAD_FAST", '_[value]'),        # invertfunc -> obj -> attr -> value
+            Instr("CALL_FUNCTION", 0x0003),        # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_call_function(i_arg: int, Instr=bc.Instr):
+        # n_stack_args = i_arg
+        return [                                   # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
+            Instr("BUILD_TUPLE", i_arg),           # func -> argtuple
+            Instr("LOAD_FAST", '_[inverter]'),     # func -> argtuple -> inverter
+            Instr("LOAD_ATTR", 'call_function'),   # func -> argtuple -> invertfunc
+            Instr("ROT_THREE"),                    # invertfunc -> func -> argtuple
+            Instr("LOAD_CONST", i_arg),            # invertfunc -> func -> argtuple -> argspec
+            Instr("LOAD_FAST", '_[value]'),        # invertfunc -> func -> argtuple -> argspec -> value
+            Instr("CALL_FUNCTION", 0x0004),        # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
+
+    def call_inverter_binary_subsrc(Instr=bc.Instr):
+        return [                                   # obj -> index
+            Instr("LOAD_FAST", '_[inverter]'),     # obj -> index -> inverter
+            Instr("LOAD_ATTR", 'binary_subscr'),   # obj -> index -> invertfunc
+            Instr("ROT_THREE"),                    # invertfunc -> obj -> index
+            Instr("LOAD_FAST", '_[value]'),        # invertfunc -> obj -> index -> value
+            Instr("CALL_FUNCTION", 0x0003),        # retval
+            Instr("RETURN_VALUE"),                 #
+        ]
 
 
 def inject_inversion(bytecode):
@@ -376,56 +559,27 @@ def inject_inversion(bytecode):
     instr = bytecode[-2]
     i_name, i_arg = instr.name, instr.arg
     new_code = bytecode[:-2]
-    if i_name == "LOAD_NAME" and len(bytecode) == 2:
-        new_code.extend([                             #
-            bc.Instr("LOAD_FAST", '_[inverter]'),     # inverter
-            bc.Instr("LOAD_ATTR", 'load_name'),       # invertfunc
-            bc.Instr("LOAD_CONST", i_arg),            # invertfunc -> name
-            bc.Instr("LOAD_FAST", '_[value]'),        # invertfunc -> name - > value
-            bc.Instr("CALL_FUNCTION", 0x0002),        # retval
-           bc.Instr ("RETURN_VALUE"),                 #
-        ])
+    # In Python 3.11 there is a RESUME in the bytecode
+    if i_name == "LOAD_NAME" and len(bytecode) >= 2:
+        new_code.extend(call_inverter_load_name(i_arg))
     elif i_name == "LOAD_ATTR":
-        new_code.extend([                   # obj
-            bc.Instr("LOAD_FAST", '_[inverter]'),     # obj -> inverter
-            bc.Instr("LOAD_ATTR", 'load_attr'),       # obj -> invertfunc
-            bc.Instr("ROT_TWO"),                      # invertfunc -> obj
-            bc.Instr("LOAD_CONST", i_arg),            # invertfunc -> obj -> attr
-            bc.Instr("LOAD_FAST", '_[value]'),        # invertfunc -> obj -> attr -> value
-            bc.Instr("CALL_FUNCTION", 0x0003),        # retval
-            bc.Instr("RETURN_VALUE"),                 #
-        ])
-
-    # In Python 3.6+ CALL_FUNCTION is only used for calls with positional arguments
-    # and the argument of the opcode is teh number of argument on the stack.
+        new_code.extend(call_inverter_load_attr(i_arg))
+    elif i_name == "CALL":
+        # TODO optimize out dead branch based on version
+        # In Python 3.11 PRECALL is before CALL
+        new_code.pop()  # Remove PRECALL
+        new_code.extend(call_inverter_call_function(i_arg))
     elif i_name == "CALL_FUNCTION":
-        n_stack_args = i_arg
-        new_code.extend([                             # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-            bc.Instr("BUILD_TUPLE", n_stack_args),    # func -> argtuple
-            bc.Instr("LOAD_FAST", '_[inverter]'),     # func -> argtuple -> inverter
-            bc.Instr("LOAD_ATTR", 'call_function'),   # func -> argtuple -> invertfunc
-            bc.Instr("ROT_THREE"),                    # invertfunc -> func -> argtuple
-            bc.Instr("LOAD_CONST", i_arg),            # invertfunc -> func -> argtuple -> argspec
-            bc.Instr("LOAD_FAST", '_[value]'),        # invertfunc -> func -> argtuple -> argspec -> value
-            bc.Instr("CALL_FUNCTION", 0x0004),        # retval
-            bc.Instr("RETURN_VALUE"),                 #
-        ])
-
+        # In Python 3.6+ CALL_FUNCTION is only used for calls with positional arguments
+        # and the argument of the opcode is the number of argument on the stack.
+        new_code.extend(call_inverter_call_function(i_arg))
     # We do not trace CALL_FUNCTION_KW and CALL_FUNCTION_EX since tracing and
     # inverting only require to detect getattr and setattr both in this project
     # and in traits-enaml. Those two are always called using the CALL_FUNCTION
     # bytecode instruction.
-
     elif i_name == "BINARY_SUBSCR":
-        new_code.extend([                             # obj -> index
-            bc.Instr("LOAD_FAST", '_[inverter]'),     # obj -> index -> inverter
-            bc.Instr("LOAD_ATTR", 'binary_subscr'),   # obj -> index -> invertfunc
-            bc.Instr("ROT_THREE"),                    # invertfunc -> obj -> index
-            bc.Instr("LOAD_FAST", '_[value]'),        # invertfunc -> obj -> index -> value
-            bc.Instr("CALL_FUNCTION", 0x0003),        # retval
-            bc.Instr("RETURN_VALUE"),                 #
-        ])
+        new_code.extend(call_inverter_binary_subsrc())
     else:
-        raise ValueError("can't invert code")
+        raise ValueError("can't invert code '%s'" % i_name)
 
     return new_code

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -14,7 +14,7 @@ from types import CodeType
 import bytecode as bc
 from atom.api import Str, Typed
 
-from ..compat import PY38
+from ..compat import PY38, PY311
 from .code_generator import CodeGenerator
 from .enaml_ast import (
     AliasExpr, ASTVisitor, Binding, ChildDef, EnamlDef, StorageExpr, Template,
@@ -200,7 +200,7 @@ def fetch_globals(cg):
         The code generator with which to write the code.
 
     """
-    cg.load_global('globals')
+    cg.load_global('globals', push_null=True)
     cg.call_function()
     cg.store_fast(F_GLOBALS)
 
@@ -358,6 +358,8 @@ def append_node(cg, parent, index):
         The index of the target node in the node list.
 
     """
+    if PY311:
+        cg.push_null()
     load_node(cg, parent)
     cg.load_attr('children')
     cg.load_attr('append')
@@ -366,7 +368,7 @@ def append_node(cg, parent, index):
     cg.pop_top()
 
 
-def safe_eval_ast(cg, node, name, lineno, local_names):
+def safe_eval_ast(cg, node, name: str, lineno: int, local_names: set):
     """ Safe eval a Python ast node.
 
     This method will eval the python code represented by the ast
@@ -417,18 +419,42 @@ def analyse_globals_and_func_defs(pyast):
     return global_vars, has_def
 
 
-def rewrite_globals_access(code, global_vars):
-    """Update the function code global loads
+if PY311:
+    def rewrite_globals_access(code, global_vars: set):
+        """Update the function code global loads
 
-    This will rewrite the function to convert each LOAD_GLOBAL opcode
-    into a LOAD_NAME opcode, unless the associated name is known to have been
-    made global via the 'global' keyword.
+        This will rewrite the function to convert each LOAD_GLOBAL opcode
+        into a LOAD_NAME opcode, unless the associated name is known to have been
+        made global via the 'global' keyword.
 
-    """
-    for idx, instr in enumerate(code):
-        if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
-                instr.arg not in global_vars):
-            instr.name = "LOAD_NAME"
+        """
+        # On Python 3.11 if the LOAD_GLOBAL has the PUSH_NULL flag set
+        # we have re-inject that when doing the rewrite or it jacks up the stack
+        inserts = []
+        for idx, instr in enumerate(code):
+            if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
+                    instr.arg not in global_vars):
+                if instr.arg[0]:
+                    inserts.append(idx)
+                code[idx] = bc.Instr("LOAD_NAME", instr.arg[1])
+
+        # Walk backwards so indexes remain valid
+        for idx in reversed(inserts):
+            code.insert(idx, bc.Instr("PUSH_NULL"))
+
+else:
+    def rewrite_globals_access(code, global_vars: set):
+        """Update the function code global loads
+
+        This will rewrite the function to convert each LOAD_GLOBAL opcode
+        into a LOAD_NAME opcode, unless the associated name is known to have been
+        made global via the 'global' keyword.
+
+        """
+        for idx, instr in enumerate(code):
+            if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
+                    instr.arg not in global_vars):
+                instr.name = "LOAD_NAME"
 
 
 def run_in_dynamic_scope(code, global_vars):
@@ -471,6 +497,9 @@ def run_in_dynamic_scope(code, global_vars):
             cg.code_ops.append(bc.Instr(i_name, i_arg))  # func
             load_helper(cg, 'wrap_func')                 # func -> wrap
             cg.rot_two()                                 # wrap -> func
+            if PY311:
+                cg.push_null()
+                cg.rot_three()
             cg.load_global('__scope__')                  # wrap -> func -> scope
             cg.call_function(2)                          # wrapped
             continue
@@ -505,6 +534,9 @@ def gen_child_def_node(cg, node, local_names):
     load_name(cg, node.typename, local_names)
     with cg.try_squash_raise():
         cg.dup_top()
+        if PY311:
+            cg.push_null()
+            cg.rot_two()
         load_helper(cg, 'validate_declarative')
         cg.rot_two()                            # base -> helper -> base
         cg.call_function(1)                     # base -> retval
@@ -513,6 +545,10 @@ def gen_child_def_node(cg, node, local_names):
     # Subclass the child class if needed
     store_types = (StorageExpr, AliasExpr, FuncDef)
     if any(isinstance(item, store_types) for item in node.body):
+
+        if PY311:
+            cg.push_null()
+            cg.rot_two()  # null -> base
 
         # Create the class code
         cg.load_build_class()
@@ -533,7 +569,6 @@ def gen_child_def_node(cg, node, local_names):
 
         class_code = class_cg.to_code()
         cg.load_const(class_code)
-        cg.load_const(None)  # XXX better qualified name
         cg.make_function()
 
         cg.rot_two()                            # builtins.__build_class_ -> class_func -> base
@@ -542,6 +577,9 @@ def gen_child_def_node(cg, node, local_names):
         cg.call_function(3)                     # class
 
     # Build the declarative compiler node
+    if PY311:
+        cg.push_null()
+        cg.rot_two()  # null -> class
     store_locals = should_store_locals(node)
     load_helper(cg, 'declarative_node')
     cg.rot_two()
@@ -573,6 +611,9 @@ def gen_template_inst_node(cg, node, local_names):
     load_name(cg, node.name, local_names)
     with cg.try_squash_raise():
         cg.dup_top()
+        if PY311:
+            cg.push_null()
+            cg.rot_two()  # null -> template
         load_helper(cg, 'validate_template')
         cg.rot_two()
         cg.call_function(1)
@@ -580,6 +621,10 @@ def gen_template_inst_node(cg, node, local_names):
 
     # Load the arguments for the instantiation call.
     arguments = node.arguments
+    if PY311:
+        cg.push_null()
+        cg.rot_two()  # null -> template
+
     for arg in arguments.args:
         safe_eval_ast(cg, arg.ast, node.name, arg.lineno, local_names)
     if arguments.stararg:
@@ -603,6 +648,9 @@ def gen_template_inst_node(cg, node, local_names):
         starname = identifiers.starname
         with cg.try_squash_raise():
             cg.dup_top()
+            if PY311:
+                cg.push_null()
+                cg.rot_two()  # null -> template_inst
             load_helper(cg, 'validate_unpack_size')
             cg.rot_two()
             cg.load_const(len(names))
@@ -611,6 +659,9 @@ def gen_template_inst_node(cg, node, local_names):
             cg.pop_top()
 
     # Load and call the helper to create the compiler node
+    if PY311:
+        cg.push_null()
+        cg.rot_two()  # null -> tmpl
     load_helper(cg, 'template_inst_node')
     cg.rot_two()
     cg.load_const(names)
@@ -685,6 +736,8 @@ def gen_template_inst_binding(cg, node, index):
 
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
+        if PY311:
+            cg.push_null()
         load_helper(cg, 'run_operator')
         load_node(cg, index)
         cg.load_fast(UNPACK_MAP)
@@ -726,6 +779,8 @@ def gen_operator_binding(cg, node, index, name):
 
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
+        if PY311:
+            cg.push_null()
         load_helper(cg, 'run_operator')
         load_node(cg, index)
         # For operators not in a template instance the scope_node and the node
@@ -759,6 +814,8 @@ def gen_alias_expr(cg, node, index):
     """
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
+        if PY311:
+            cg.push_null()
         load_helper(cg, 'add_alias')
         load_node(cg, index)
         cg.load_const(node.name)
@@ -791,6 +848,8 @@ def gen_storage_expr(cg, node, index, local_names):
     """
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
+        if PY311:
+            cg.push_null()
         load_helper(cg, 'add_storage')
         load_node(cg, index)
         cg.load_const(node.name)
@@ -838,9 +897,15 @@ def _insert_decl_function(cg, funcdef):
     #   LOAD_CONST      (qualified name)
     #   MAKE_FUCTION    (num defaults)      // TOS
 
+    # On Python 3.11 the stack is
+    #   ...
+    #   LOAD_CONST      (<code object>)
+    #   MAKE_FUCTION    (num defaults)      // TOS
+    code_index = -2 if PY311 else -3
+
     # extract the inner code object which represents the actual
     # function code and update its flags
-    inner = bc.Bytecode.from_code(outer_ops[-3].arg)
+    inner = bc.Bytecode.from_code(outer_ops[code_index].arg)
     inner.flags ^= (inner.flags & bc.CompilerFlags.NEWLOCALS)
 
     # On Python 3 all comprehensions use a function call. To avoid scoping
@@ -850,7 +915,7 @@ def _insert_decl_function(cg, funcdef):
     else:
         rewrite_globals_access(inner, global_vars)
 
-    outer_ops[-3].arg = inner.to_code()
+    outer_ops[code_index].arg = inner.to_code()
 
     # inline the modified code ops into the code generator
     cg.code_ops.extend(outer_ops)
@@ -876,6 +941,8 @@ def gen_decl_funcdef(cg, node, index):
     """
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
+        if PY311:
+            cg.push_null()
         load_helper(cg, 'add_decl_function')
         load_node(cg, index)
         _insert_decl_function(cg, node.funcdef)

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2020, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -895,12 +895,12 @@ def _insert_decl_function(cg, funcdef):
     #   ...
     #   LOAD_CONST      (<code object>)
     #   LOAD_CONST      (qualified name)
-    #   MAKE_FUCTION    (num defaults)      // TOS
+    #   MAKE_FUCTION    (flag)              // TOS
 
     # On Python 3.11 the stack is
     #   ...
     #   LOAD_CONST      (<code object>)
-    #   MAKE_FUCTION    (num defaults)      // TOS
+    #   MAKE_FUCTION    (flag)              // TOS
     code_index = -2 if PY311 else -3
 
     # extract the inner code object which represents the actual

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/declarative_meta.py
+++ b/enaml/core/declarative_meta.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -11,6 +11,7 @@ from . import compiler_common as cmn
 from .enaml_ast import Module
 from .enamldef_compiler import EnamlDefCompiler
 from .template_compiler import TemplateCompiler
+from ..compat import PY311
 
 # Increment this number whenever the compiler changes the code which it
 # generates. This number is used by the import hooks to know which version
@@ -214,9 +215,10 @@ class EnamlCompiler(cmn.CompilerBase):
     def visit_EnamlDef(self, node):
         # Invoke the enamldef code and store result in the namespace.
         cg = self.code_generator
+        if PY311:
+            cg.push_null()
         code = EnamlDefCompiler.compile(node, cg.filename)
         cg.load_const(code)
-        cg.load_const(None)  # XXX better qualified name
         cg.make_function()
         cg.call_function()
         cg.store_global(node.typename)
@@ -226,11 +228,15 @@ class EnamlCompiler(cmn.CompilerBase):
         cg.set_lineno(node.lineno)
 
         with cg.try_squash_raise():
+            if PY311:
+                cg.push_null()
 
             # Load and validate the parameter specializations
             for index, param in enumerate(node.parameters.positional):
                 spec = param.specialization
                 if spec is not None:
+                    if PY311:
+                        cg.push_null()
                     cmn.load_helper(cg, 'validate_spec', from_globals=True)
                     cg.load_const(index)
                     cmn.safe_eval_ast(
@@ -257,17 +263,13 @@ class EnamlCompiler(cmn.CompilerBase):
             # Generate the template code and function
             code = TemplateCompiler.compile(node, cg.filename)
             cg.load_const(code)
-
-            # Under Python 3 function have a qualified name
-            # XXX improve qualified name
-            cg.load_const(None)
             cg.make_function(0x01)
 
             # Load and call the helper which will build the template
             cmn.load_helper(cg, 'make_template', from_globals=True)
             cg.rot_three()
             cg.load_const(node.name)
-            cg.load_global('globals')
+            cg.load_global('globals', push_null=True)
             cg.call_function()
             cg.load_global(cmn.TEMPLATE_MAP)
             cg.call_function(5)

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2019, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -8,7 +8,7 @@
 from . import block_compiler as block
 from . import compiler_common as cmn
 from .enaml_ast import EnamlDef
-from ..compat import POS_ONLY_ARGS
+from ..compat import POS_ONLY_ARGS, PY311
 
 
 class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
@@ -81,6 +81,9 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg = self.code_generator
         cg.set_lineno(node.lineno)
 
+        if PY311:
+            cg.push_null()
+
         # Preload the helper to generate the enamldef
         cmn.load_helper(cg, 'make_enamldef')
 
@@ -91,6 +94,9 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         # Validate the type of the base class
         with cg.try_squash_raise():
             cg.dup_top()
+            if PY311:
+                cg.push_null()  # base -> null
+                cg.rot_two()    # null -> base
             cmn.load_helper(cg, 'validate_declarative')
             cg.rot_two()                            # helper -> name -> base -> helper -> base
             cg.call_function(1)                     # helper -> name -> base -> retval
@@ -117,6 +123,9 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         cg.call_function(3)                         # class
 
         # Build the compiler node
+        if PY311:
+            cg.push_null()
+            cg.rot_two()
         should_store = cmn.should_store_locals(node)
         cmn.load_helper(cg, 'enamldef_node')
         cg.rot_two()
@@ -133,6 +142,8 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
             self.visit(item)
 
         # Update the internal node ids for the hierarchy.
+        if PY311:
+            cg.push_null()
         cmn.load_node(cg, 0)
         cg.load_attr('update_id_nodes')
         cg.call_function()
@@ -257,14 +268,17 @@ class EnamlDefCompiler(cmn.CompilerBase):
         )
 
         # Prepare the code block for execution.
+        if PY311:
+            cg.push_null()
         cmn.fetch_helpers(cg)
         cmn.load_helper(cg, 'make_object')
         cg.call_function()
         cg.store_fast(cmn.SCOPE_KEY)
 
         # Load and invoke the first pass code object.
+        if PY311:
+            cg.push_null()
         cg.load_const(first_code)
-        cg.load_const(None)  # XXX better qualified name
         cg.make_function()
         for arg in first_args:
             cg.load_fast(arg)
@@ -272,8 +286,9 @@ class EnamlDefCompiler(cmn.CompilerBase):
         cg.store_fast(cmn.NODE_LIST)
 
         # Load and invoke the second pass code object.
+        if PY311:
+            cg.push_null()
         cg.load_const(second_code)
-        cg.load_const(None)  # XXX better qualified name
         cg.make_function()
         for arg in second_args:
             cg.load_fast(arg)

--- a/enaml/core/parser/__init__.py
+++ b/enaml/core/parser/__init__.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/parser/base_enaml_parser.py
+++ b/enaml/core/parser/base_enaml_parser.py
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2021-2022, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/parser/base_python_parser.py
+++ b/enaml/core/parser/base_python_parser.py
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2021-2022, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/parser/enaml.gram
+++ b/enaml/core/parser/enaml.gram
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------------------
-# Copyright (c) 2021-2022, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@
 
 @header'''
 #---------------------------------------------------------------------------------------
-# Copyright (c) 2021-2022, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/parser/enaml_parser.py
+++ b/enaml/core/parser/enaml_parser.py
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------------------------
-# Copyright (c) 2021-2022, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/standard_inverter.py
+++ b/enaml/core/standard_inverter.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2020, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -62,7 +62,7 @@ class StandardTracer(CodeTracer):
     (obj, name) pairs of atom items discovered during tracing.
 
     """
-    __slots__ = ('owner', 'name', 'items')
+    __slots__ = ('owner', 'name', 'key', 'items')
 
     def __init__(self, owner, name):
         """ Initialize a StandardTracer.
@@ -70,12 +70,13 @@ class StandardTracer(CodeTracer):
         """
         self.owner = owner
         self.name = name
+        self.key = '_[%s|trace]' % name
         self.items = set()
 
     #--------------------------------------------------------------------------
     # Utility Methods
     #--------------------------------------------------------------------------
-    def trace_atom(self, obj, name):
+    def trace_atom(self, obj: Atom, name: str):
         """ Add the atom object and name pair to the traced items.
 
         Parameters
@@ -105,7 +106,7 @@ class StandardTracer(CodeTracer):
         """
         owner = self.owner
         name = self.name
-        key = '_[%s|trace]' % name
+        key = self.key
         storage = owner._d_storage
 
         # invalidate the old observer so that it can be collected
@@ -143,14 +144,13 @@ class StandardTracer(CodeTracer):
         if isinstance(obj, Atom):
             self.trace_atom(obj, attr)
 
-    def call_function(self, func, argtuple, argspec):
+    def call_function(self, func, argtuple: tuple, nargs: int):
         """ Called before the CALL_FUNCTION opcode is executed.
 
         This will trace the func if it is the builtin `getattr` and the
         object is an Atom instance. See also: `CodeTracer.call_function`
 
         """
-        nargs = argspec
         if (func is getattr and (nargs == 2 or nargs == 3)):
             obj, attr = argtuple[0], argtuple[1]
             if isinstance(obj, Atom) and isinstance(attr, str):

--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2020, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/core/template_.py
+++ b/enaml/core/template_.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2020, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/drag_drop.py
+++ b/enaml/drag_drop.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2014-2021, Nucleic Development Team.
+# Copyright (c) 2014-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/__init__.py
+++ b/enaml/qt/__init__.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/__init__.py
+++ b/enaml/qt/docking/__init__.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/event_types.py
+++ b/enaml/qt/docking/event_types.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/layout_builder.py
+++ b/enaml/qt/docking/layout_builder.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_bitmap_button.py
+++ b/enaml/qt/docking/q_bitmap_button.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_dock_bar.py
+++ b/enaml/qt/docking/q_dock_bar.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_dock_frame.py
+++ b/enaml/qt/docking/q_dock_frame.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022 Nucleic Development Team.
+# Copyright (c) 2013-2023 Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_dock_tab_widget.py
+++ b/enaml/qt/docking/q_dock_tab_widget.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_dock_title_bar.py
+++ b/enaml/qt/docking/q_dock_title_bar.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/docking/q_dock_window.py
+++ b/enaml/qt/docking/q_dock_window.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/q_deferred_caller.py
+++ b/enaml/qt/q_deferred_caller.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/q_popup_view.py
+++ b/enaml/qt/q_popup_view.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/q_window_base.py
+++ b/enaml/qt/q_window_base.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2020, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/qt_datetime_selector.py
+++ b/enaml/qt/qt_datetime_selector.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/qt_notebook.py
+++ b/enaml/qt/qt_notebook.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/qt_scintilla.py
+++ b/enaml/qt/qt_scintilla.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/qt_stack.py
+++ b/enaml/qt/qt_stack.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/qt/scintilla_lexers.py
+++ b/enaml/qt/scintilla_lexers.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/widgets/abstract_button.py
+++ b/enaml/widgets/abstract_button.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2019, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/widgets/dock_events.py
+++ b/enaml/widgets/dock_events.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/widgets/dual_slider.py
+++ b/enaml/widgets/dual_slider.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/enaml/widgets/widget.py
+++ b/enaml/widgets/widget.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2021, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,7 +10,7 @@
 name = "enaml"
 description = "Declarative DSL for building rich user interfaces in Python"
 readme = "README.rst"
-requires-python = ">=3.8,!3.11.0,!3.11.1"
+requires-python = ">=3.8,!=3.11.0,!=3.11.1"
 license = {file = "LICENSE"}
 authors = [
   {name = "The Nucleic Development Team", email = "sccolbert@gmail.com"}
@@ -82,7 +82,7 @@ include-package-data = false
 write_to = "enaml/version.py"
 write_to_template = """
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 name = "enaml"
 description = "Declarative DSL for building rich user interfaces in Python"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.8,!3.11.0,!3.11.1"
 license = {file = "LICENSE"}
 authors = [
   {name = "The Nucleic Development Team", email = "sccolbert@gmail.com"}
@@ -25,11 +25,12 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
     "ply",
-    "atom>=0.8.0",  # XXX bump for add_members
+    "atom>=0.9.0",
     "kiwisolver>=1.2.0",
     "bytecode>=0.13.0",
     "pegen>=0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/core/parser/conftest.py
+++ b/tests/core/parser/conftest.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2018-2022, Nucleic Development Team.
+# Copyright (c) 2018-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/core/test_code_tracing.py
+++ b/tests/core/test_code_tracing.py
@@ -1,0 +1,146 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2022, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+from textwrap import dedent
+from utils import compile_source
+
+
+def test_tracer_load_attr():
+    source = dedent("""\
+    from atom.api import Atom, Str
+    from enaml.widgets.api import Window, Container, Label
+
+    class Model(Atom):
+        value = Str("foo")
+
+    enamldef Main(Window):
+        alias lbl
+        attr model = Model()
+        Container:
+            Label: lbl:
+                text << model.value
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    assert window.lbl.text == "foo"
+    window.model.value = "bar"
+    assert window.lbl.text == "bar"
+
+
+def test_tracer_call_func():
+    source = dedent("""\
+    from atom.api import Atom, Int
+    from enaml.widgets.api import Window, Container, Label
+
+    class Model(Atom):
+        value = Int(1)
+
+    enamldef Main(Window):
+        alias lbl
+        attr model = Model()
+        Container:
+            Label: lbl:
+                text << str(model.value)
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    assert window.lbl.text == "1"
+    window.model.value = 2
+    assert window.lbl.text == "2"
+
+
+def test_tracer_binary_subscr():
+    source = dedent("""\
+    from atom.api import Atom, ContainerList
+    from enaml.widgets.api import Window, Container, SpinBox
+
+    class Model(Atom):
+        items = ContainerList(default=[1])
+
+    enamldef Main(Window):
+        alias sb
+        attr model = Model()
+        Container:
+            SpinBox: sb:
+                value << model.items[0]
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    window.model.items[0] = 3
+    assert window.sb.value == 3
+
+
+def test_inverter_load_attr():
+    source = dedent("""\
+    from atom.api import Atom, Int
+    from enaml.widgets.api import Window, Container, Label, SpinBox
+
+    class Model(Atom):
+        value = Int(0)
+
+    enamldef Main(Window):
+        alias sb
+        attr model = Model()
+        Container:
+            SpinBox: sb:
+                value := model.value
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    assert window.sb.value == 0
+    window.sb.value = 2
+    assert window.model.value == 2
+    window.model.value = 3
+    assert window.sb.value == 3
+
+
+def test_inverter_call_func():
+    source = dedent("""\
+    from atom.api import Atom, Int
+    from enaml.widgets.api import Window, Container, Label, SpinBox
+
+    class Model(Atom):
+        value = Int(0)
+
+    enamldef Main(Window):
+        alias sb
+        attr model = Model()
+        Container:
+            SpinBox: sb:
+                value := getattr(model, "value")
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    assert window.sb.value == 0
+    window.sb.value = 2
+    assert window.model.value == 2
+    window.model.value = 3
+    assert window.sb.value == 3
+
+
+def test_inverter_binary_subscr():
+    source = dedent("""\
+    from atom.api import Atom, ContainerList
+    from enaml.widgets.api import Window, Container, SpinBox
+
+    class Model(Atom):
+        items = ContainerList(default=[1])
+
+    enamldef Main(Window):
+        alias sb
+        attr model = Model()
+        Container:
+            SpinBox: sb:
+                value := model.items[0]
+    """)
+    Main = compile_source(source, 'Main')
+    window = Main()
+    assert window.sb.value == 1
+    window.sb.value = 2
+    assert window.model.items[0] == 2
+    window.model.items[0] = 3
+    assert window.sb.value == 3

--- a/tests/core/test_compiler.py
+++ b/tests/core/test_compiler.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2020-2021, Nucleic Development Team.
+# Copyright (c) 2020-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/core/test_declarative_function.py
+++ b/tests/core/test_declarative_function.py
@@ -93,6 +93,25 @@ def test_declarative_function_get_and_call():
     assert '1 argument' in excinfo.exconly()
 
 
+def test_declarative_function_defaults():
+    """Test calling DeclarativeFunction and BoundDeclarativeMethod.
+
+    """
+    source = dedent("""\
+    from enaml.widgets.window import Window
+
+    enamldef MyWindow(Window): main:
+
+        func call(arg, kwarg=1):
+            return arg, kwarg
+    """)
+    tester = compile_source(source, 'MyWindow')()
+    r = tester.call(2)
+    assert r == (2, 1)
+    r = tester.call(2, 3)
+    assert r == (2, 3)
+
+
 def test_declarative_function_eq_and_hash():
     """Test that BoundDeclarativeMethod eq works.
 

--- a/tests/core/test_looper.py
+++ b/tests/core/test_looper.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2019-2022, Nucleic Development Team.
+# Copyright (c) 2019-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2019-2022, Nucleic Development Team.
+# Copyright (c) 2019-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/core/test_zipimporter.py
+++ b/tests/core/test_zipimporter.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_compileall.py
+++ b/tests/test_compileall.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_flow_layout.py
+++ b/tests/test_flow_layout.py
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_layout_container.py
+++ b/tests/test_layout_container.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_q_resource_helpers.py
+++ b/tests/test_q_resource_helpers.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2018-2022, Nucleic Development Team.
+# Copyright (c) 2018-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/widgets/test_button_group.py
+++ b/tests/widgets/test_button_group.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2019-2022, Nucleic Development Team.
+# Copyright (c) 2019-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/widgets/test_focus_tracker.py
+++ b/tests/widgets/test_focus_tracker.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2020-2022, Nucleic Development Team.
+# Copyright (c) 2020-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/widgets/test_focus_traversal.py
+++ b/tests/widgets/test_focus_traversal.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2020-2022, Nucleic Development Team.
+# Copyright (c) 2020-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tests/widgets/test_image_view.py
+++ b/tests/widgets/test_image_view.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2019-2022, Nucleic Development Team.
+# Copyright (c) 2019-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/tools/pygments/pyproject.toml
+++ b/tools/pygments/pyproject.toml
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2013-2022, Nucleic Development Team.
+# Copyright (c) 2013-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
This updates the code generator/compiler to work with Python 3.11, it builds on the pegen branch because the main branch just fails due to invalid col offsets in the ast. 

- It seems like the python docs are wrong with MAKE_FUNCTION as there is now no need to push a qualname (https://github.com/python/cpython/issues/93270).
- Since POP_BLOCK was removed, I'm not sure if `try_squash_raise` can still be implemented?
- There is still a weird problem with decl funcs with default args. Inspect shows the signature is correct and funchelper shows the correct number of defaults but for some reason it does not use the defaults?

On a positive note I get about a 10-15% speedup with this on enaml-web :).