### PR TITLE
Make tests pass after 2038

### DIFF
--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -307,7 +307,7 @@ class EnamlImporter(AbstractEnamlImporter):
                 os.mkdir(file_info.cache_dir)
             with open(file_info.cache_path, 'w+b') as cache_file:
                 cache_file.write(MAGIC_NUMBER)
-                cache_file.write(struct.pack('i', ts))
+                cache_file.write(struct.pack('<L', ts & 0xFFFF_FFFF))
                 marshal.dump(code, cache_file)
         except (OSError, IOError):
             pass
@@ -328,7 +328,7 @@ class EnamlImporter(AbstractEnamlImporter):
         """
         with open(file_info.cache_path, 'rb') as cache_file:
             magic = cache_file.read(4)
-            timestamp = struct.unpack('i', cache_file.read(4))[0]
+            timestamp = struct.unpack('<L', cache_file.read(4))[0]
         return (magic, timestamp)
 
     def read_source(self):


### PR DESCRIPTION
Make tests pass after 2038

This patch was inspired by https://github.com/python/cpython/commit/0af681b652c43f0ba90988400ecc1e7934fbfc5d

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.