### PR TITLE
Implement hash and eq for bound decl func

### DIFF
--- a/enaml/src/declarative_function.cpp
+++ b/enaml/src/declarative_function.cpp
@@ -360,6 +360,48 @@ BoundDMethod__call__( BoundDMethod* self, PyObject* args, PyObject* kwargs )
 
 
 PyObject*
+BoundDMethod_richcompare( BoundDMethod* self, PyObject* other, int opid  )
+{
+    if( opid == Py_EQ )
+    {
+        if( PyObject_TypeCheck( other, BoundDMethod::TypeObject ) )
+        {
+            BoundDMethod* other_bmeth = reinterpret_cast<BoundDMethod*>( other );
+            if(
+                self->im_self == other_bmeth->im_self
+                && self->im_key == other_bmeth->im_key
+                && self->im_func == other_bmeth->im_func
+            )
+                Py_RETURN_TRUE;
+        }
+        Py_RETURN_FALSE;
+    }
+    Py_RETURN_NOTIMPLEMENTED;
+}
+
+
+static Py_hash_t
+BoundDMethod_hash(BoundDMethod *self)
+{
+    Py_hash_t x, y, z;
+    x = _Py_HashPointer(self->im_self);
+    y = PyObject_Hash(self->im_func);
+    if (y == -1)
+        return -1;
+    z = PyObject_Hash(self->im_key);
+    if (z == -1)
+        return -1;
+    x = x ^ y;
+    if (x == -1)
+        x = -2;
+    x = x ^ z;
+    if (x == -1)
+        x = -2;
+    return x;
+}
+
+
+PyObject*
 BoundDMethod_get_func( BoundDMethod* self, void* ctxt )
 {
     return cppy::incref( self->im_func );
@@ -397,7 +439,9 @@ static PyType_Slot BoundDMethod_Type_slots[] = {
     { Py_tp_traverse, void_cast( BoundDMethod_traverse ) },      /* tp_traverse */
     { Py_tp_clear, void_cast( BoundDMethod_clear ) },            /* tp_clear */
     { Py_tp_getset, void_cast( BoundDMethod_getset ) },          /* tp_getset */
-    { Py_tp_call, void_cast( BoundDMethod__call__ ) },              /* tp_call */
+    { Py_tp_call, void_cast( BoundDMethod__call__ ) },           /* tp_call */
+    { Py_tp_richcompare, void_cast( BoundDMethod_richcompare ) },/* tp_richcompare */
+    { Py_tp_hash, void_cast( BoundDMethod_hash ) },              /* tp_hash */
     { Py_tp_repr, void_cast( BoundDMethod_repr ) },              /* tp_repr */
     { Py_tp_alloc, void_cast( PyType_GenericAlloc ) },           /* tp_alloc */
     { Py_tp_free, void_cast( PyObject_GC_Del ) },                /* tp_free */

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -12,6 +12,7 @@ Dates are written as DD/MM/YYYY
   It however comes with a speed penalty (x4 slowdown). There will be efforts to
   mitigate this but since parsing should occurs only once for deployed application
   the gains are expected to out weight the cost here.
+- implement hash and eq for decl functions PR #517
 
 0.15.2 - 19/08/2022
 -------------------

--- a/tests/core/test_declarative_function.py
+++ b/tests/core/test_declarative_function.py
@@ -93,6 +93,35 @@ def test_declarative_function_get_and_call():
     assert '1 argument' in excinfo.exconly()
 
 
+def test_declarative_function_eq_and_hash():
+    """Test that BoundDeclarativeMethod eq works.
+
+    """
+    source = dedent("""\
+    from enaml.widgets.window import Window
+
+    enamldef MyWindow(Window): main:
+
+        func foo(arg):
+            return arg
+
+        func bar():
+            return main
+
+    """)
+    MyWindow = compile_source(source, 'MyWindow')
+    tester = MyWindow()
+    foo = tester.foo
+    assert tester.foo == foo
+    assert tester.foo != tester.bar
+    assert foo != tester.bar
+    assert hash(foo) == hash(tester.foo)
+
+    tester2 = MyWindow()
+    assert tester2.foo != tester.foo
+    assert hash(foo) != hash(tester2.foo)
+
+
 def test_calling_super():
     """Test calling a declarative function using super.
 


### PR DESCRIPTION
Currently if you use observe with a decl func it is impossible to remove the observer unless you clear all observers. This fixes that. 

A simple example to show the problem.  

```python
from atom.api import Atom, Str
from enaml.widgets.api import Window, Container, Label, Field, PushButton


class Model(Atom):
    output = Str()


enamldef Main(Window): window:
    attr model = Model()
    func decl_print(x):
        print(x)

    Container:
        PushButton:
            text = "Add observer"
            clicked :: model.observe("output", decl_print)
        PushButton:
            text = "Remove observer"
            clicked :: model.unobserve("output", decl_print)
        Field:
            submit_triggers = ["auto_sync"]
            text := model.output

```

The hash function is based on cpythons method_hash (see https://github.com/python/cpython/blob/81f7359f67a7166d57a10a3d5366406d9c85f1de/Objects/classobject.c#L298)