### PR TITLE
Fix bug in undocking items from a tab layout

### DIFF
--- a/enaml/qt/docking/q_dock_tab_widget.py
+++ b/enaml/qt/docking/q_dock_tab_widget.py
@@ -347,7 +347,7 @@ class QDockTabBar(QTabBar):
             )
             QApplication.sendEvent(self, evt)
             container = self.parent().widget(self.currentIndex())
-            container.untab(gpos())
+            container.untab(gpos)
             self._has_mouse = False
 
     def mouseReleaseEvent(self, event):


### PR DESCRIPTION
This fixes the following error when attempting to use the mouse to undock a dock item that's part of a tab group:
```
Traceback (most recent call last):
  File "c:\Users\lbhb\anaconda3\envs\psi-nafc\Lib\site-packages\enaml\qt\docking\q_dock_tab_widget.py", line 350, in mouseMoveEvent
    container.untab(gpos())
                    ^^^^^^
TypeError: 'QPoint' object is not callable
```

I tried updating the unit-tests to catch this issue, but could not even figure out how to click on a dock item titlebar. For example, this code *should* work, but even during the `enaml_qtbot.wait(5000)`, I see no evidence that `item_7` was activated in the dock area (this is using the `test_dock_layout.py`). 
```
        di = dock.find('item_7')
        tb = di.proxy.widget.titleBarWidget()
        title = tb._title_label
        pos = title.mapTo(tb, title.pos())
        enaml_qtbot.mouseClick(tb, Qt.LeftButton, pos=pos)
        enaml_qtbot.wait(5000)
``` 
I'm guessing if we can figure out a way to properly target one of the dock items in a tab group, then we would do `mousePress` followed by a `mouseMove` to some other area which would capture the bug.