### PR TITLE
Fix code generation for inserted Python block on Python 3.10+

### DIFF
--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -566,9 +566,8 @@ class CodeGenerator(Atom):
                         # We use a NOP to be sure to always have a valid jump target
                         new_end = new_end or cfg.add_block([bc.Instr("NOP")])
                         block.append(bc.Instr("JUMP_FORWARD", new_end))
-
-            if new_end is not None:
-                last_block.next_block = new_end
+                    elif new_end is not None:
+                        last_block.next_block = new_end
 
             bc_code = cfg.to_bytecode()
         # Skip the LOAD_CONST RETURN_VALUE pair if it exists

--- a/tests/core/test_code_generator.py
+++ b/tests/core/test_code_generator.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2021, Nucleic Development Team.
+# Copyright (c) 2021-2023, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,6 +11,17 @@ import pytest
 
 from enaml.core.code_generator import CodeGenerator
 
+# See Issue #521
+IMPORT_SRC = """
+import logging
+log = logging.getLogger(__name__)
+try:
+    import backend_1
+    backend_1_available = True
+except ImportError as e:
+    log.exception(e)
+    backend_1_available = False
+"""
 
 # Since we cannot have a return outside a function I am not sure we can ever
 # encounter a non-implicit return opcode.
@@ -19,6 +30,7 @@ from enaml.core.code_generator import CodeGenerator
     ("if a:\n    print("")", []),
     ("for i in range(10):\n    i", []),
     ("with open(f) as f:\n   print(f.readlines())", []),
+    (IMPORT_SRC, [])
 ])
 def test_python_block_insertion(source, return_on_lines):
     cg = CodeGenerator()


### PR DESCRIPTION
On Python 3.11 in particular one can often find a last block which acts as an error handling block which should not be connected to the code we want to append after the block.