### PR TITLE
Add initial enamldef const storage

### DIFF
--- a/enaml/core/block_compiler.py
+++ b/enaml/core/block_compiler.py
@@ -111,6 +111,10 @@ class FirstPassBlockCompiler(BaseBlockCompiler):
         # Grab the index of the parent node for later use.
         self.aux_index_map[node] = self.parent_index()
 
+    def visit_ConstExpr(self, node):
+        # Grab the index of the parent node for later use.
+        self.aux_index_map[node] = self.parent_index()
+
     def visit_FuncDef(self, node):
         # Grab the index of the parent node for later use.
         self.aux_index_map[node] = self.parent_index()
@@ -179,6 +183,12 @@ class SecondPassBlockCompiler(BaseBlockCompiler):
         cmn.gen_storage_expr(cg, node, index, self.local_names)
         if node.expr is not None:
             cmn.gen_operator_binding(cg, node.expr, index, node.name)
+
+    def visit_ConstExpr(self, node):
+        # Generate the code for the const expression.
+        cg = self.code_generator
+        index = self.parent_index()
+        cmn.gen_const_expr(cg, node, index, self.local_names)
 
     def visit_FuncDef(self, node):
         # Generate the code for the function declaration.

--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 from functools import update_wrapper
 
-from atom.api import Event, Instance, Member, add_member
+from atom.api import Event, Instance, Member, ReadOnly, add_member
 from atom.datastructures.api import sortedmap
 
 from .alias import Alias
@@ -125,7 +125,7 @@ def add_storage(node, name, store_type, kind):
     store_type : type or None
         The type of values to allow on the attribute.
 
-    kind : 'attr' or 'event'
+    kind : 'attr', 'event', or 'const'
         The kind of storage to add to the class.
 
     """
@@ -151,6 +151,8 @@ def add_storage(node, name, store_type, kind):
         new = d_(Event(store_type), writable=False, final=False)
     elif kind == 'attr':
         new = d_(Instance(store_type), final=False)
+    elif kind == 'const':
+        new = d_(ReadOnly(store_type), final=False)
     else:
         raise RuntimeError("invalid kind '%s'" % kind)
 

--- a/enaml/core/parser/enaml.gram
+++ b/enaml/core/parser/enaml.gram
@@ -164,6 +164,7 @@ child_def_simple_item:
     | ex_binding
     | alias_expr
     | storage_expr
+    | const_expr
     | 'pass' NEWLINE { ast.Pass(LOCATIONS) }
 
 # --- Binding --------------------------------------------------------------------------

--- a/enaml/core/parser/enaml_parser.py
+++ b/enaml/core/parser/enaml_parser.py
@@ -21,8 +21,6 @@ from .base_enaml_parser import BaseEnamlParser as Parser
 Load = ast.Load()
 Store = ast.Store()
 Del = ast.Del()
-
-
 # Keywords and soft keywords are listed at the end of the parser definition.
 class EnamlParser(Parser):
     @memoize
@@ -416,7 +414,7 @@ class EnamlParser(Parser):
 
     @memoize
     def child_def_simple_item(self) -> Optional[Any]:
-        # child_def_simple_item: binding | ex_binding | alias_expr | storage_expr | 'pass' NEWLINE
+        # child_def_simple_item: binding | ex_binding | alias_expr | storage_expr | const_expr | 'pass' NEWLINE
         mark = self._mark()
         tok = self._tokenizer.peek()
         start_lineno, start_col_offset = tok.start
@@ -431,6 +429,9 @@ class EnamlParser(Parser):
         self._reset(mark)
         if storage_expr := self.storage_expr():
             return storage_expr
+        self._reset(mark)
+        if const_expr := self.const_expr():
+            return const_expr
         self._reset(mark)
         if (self.expect("pass")) and (self.expect("NEWLINE")):
             tok = self._tokenizer.get_last_non_whitespace_token()

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -147,3 +147,131 @@ def test_attr_type_1(enaml_qtbot, enaml_sleep):
     # Should raise a type error
     with pytest.raises(TypeError):
         tester.d = datetime.time(7, 0)
+
+
+#------------------------------------------------------------------------------
+# Const Syntax
+#------------------------------------------------------------------------------
+def test_const_syntax_1():
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const editing = False
+    """)
+    compile_source(source, 'Main')
+
+
+def test_const_syntax_2():
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const message: str = "Hello world"
+    """)
+    compile_source(source, 'Main')
+
+
+def test_const_syntax_3():
+    # ChildDef const
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        Label:
+            const show_extra = False
+    """)
+    compile_source(source, 'Main')
+
+
+def test_bad_const_syntax_1():
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const enabled
+    """)
+    with pytest.raises(SyntaxError):
+        compile_source(source, 'Main')
+
+
+def test_bad_const_syntax_2():
+    # Must have an expr
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const enabled: bool
+    """)
+    with pytest.raises(SyntaxError):
+        compile_source(source, 'Main')
+
+
+def test_bad_const_syntax_3():
+    # Invalid op
+    source = dedent("""\
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const message: str << str(self)
+    """)
+    with pytest.raises(SyntaxError):
+        compile_source(source, 'Main')
+
+
+def test_const_expr_1(enaml_qtbot, enaml_sleep):
+    import datetime
+    source = dedent("""\
+    import datetime
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const d: datetime.date = datetime.date.today()
+        Container:
+            Label:
+                text << str(d)
+    """)
+    tester = compile_source(source, 'Main')()
+    tester.show()
+    wait_for_window_displayed(enaml_qtbot, tester)
+
+    # const cannot be changed
+    with pytest.raises(TypeError):
+        tester.d = (datetime.datetime.now() - datetime.timedelta(days=1)).date()
+
+
+def test_const_expr_2(enaml_qtbot, enaml_sleep):
+    import datetime
+    source = dedent("""\
+    import datetime
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const d: datetime.date = "1970-1-1"
+    """)
+    tester = compile_source(source, 'Main')()
+    tester.show()
+    wait_for_window_displayed(enaml_qtbot, tester)
+
+    # const type expr invalid
+    with pytest.raises(TypeError):
+        tester.d
+
+
+def test_const_expr_3(enaml_qtbot, enaml_sleep):
+    from datetime import datetime
+    source = dedent("""\
+    import datetime
+    from enaml.widgets.api import *
+
+    enamldef Main(Window):
+        const d: datetime.date = None
+    """)
+    today = datetime.now().date()
+    tester = compile_source(source, 'Main')(d=today)
+    tester.show()
+    wait_for_window_displayed(enaml_qtbot, tester)
+
+    # const initial value can be passed in
+    assert tester.d == today
+


### PR DESCRIPTION
This makes the parser allow a "const" in an enamldef or child def that uses atom's `ReadOnly` member so it cannot be changed after the initial value is set. The only other difference from an attr is that the parser requires a default expression.

The existing parser (pegen not the ply one) actually allows "const" in an enamldef but not in a child def but throws an error because the visitor is not implemented in the block compiler.

I copied a lot of code in the gen_const_expr, idk if that can/should be cleaned up. It's mainly an inlined gen_storage_expr and gen_operator_expr.

An example use case...
```python
from enaml.widgets.api import Window, Container, Label, PushButton

enamldef Main(Window): window:
    const locked: bool = True
    Container:
        Label:
            text = "Locked" if locked else "Unlocked"
        PushButton:
            text = "Try to unlock"
            clicked ::
                try:
                    window.locked = False
                except TypeError:
                    print("Nope!")

```

Any feedback is welcome.