### PR TITLE
Fix potential error in rewrite fast locals on 3.12 for #548

### DIFF
--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -588,10 +588,14 @@ class CodeGenerator(Atom):
         stored_names = set()
         code_ops = self.code_ops
         for idx, instr in enumerate(code_ops):
+            if not isinstance(instr, bc.Instr):
+                continue
             if instr.name == "STORE_NAME":
                 stored_names.add(instr.arg)
                 instr.name = "STORE_FAST"
         for idx, instr in enumerate(code_ops):
+            if not isinstance(instr, bc.Instr):
+                continue
             i_name = instr.name
             if i_name == "LOAD_NAME":
                 i_arg = instr.arg

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,10 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.17.1 - unreleased
+-------------------
+- fix possible error in rewrite fast locals when using templates on 3.12 PR #550
+
 0.17.0 - 20/11/2023
 -------------------
 - support for Python 3.12 PR #535

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -241,6 +241,24 @@ def test_syntax_20():
     compile_source(source, 'Main')
 
 
+def test_syntax_21():
+    source = dedent("""\
+    template Other(*Args):
+        Slider:
+            pass
+
+    template Main(Model):
+        const args = [
+            m for m in Model.members().values()
+            if isinstance(m, Float)
+        ]
+        Other(args): *all:
+            pass
+
+    """)
+    compile_source(source, 'Main')
+
+
 #------------------------------------------------------------------------------
 # Bad Template Syntax
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a few isinstance checks needed in rewrite_fast_locals on python 3.12. Fixes #548 