### PR TITLE
Add nonblocking open support to Dialog

### DIFF
--- a/enaml/qt/qt_dialog.py
+++ b/enaml/qt/qt_dialog.py
@@ -102,6 +102,12 @@ class QtDialog(QtWindow, ProxyDialog):
         """
         return bool(self.widget.exec_())
 
+    def open(self):
+        """ Launch the dialog as a modal window.
+
+        """
+        self.widget.open()
+
     def done(self, result):
         """ Close the dialog and set the result code.
 

--- a/enaml/widgets/dialog.py
+++ b/enaml/widgets/dialog.py
@@ -22,6 +22,9 @@ class ProxyDialog(ProxyWindow):
     def exec_(self):
         raise NotImplementedError
 
+    def open(self):
+        raise NotImplementedError
+
     def done(self, result):
         raise NotImplementedError
 
@@ -67,6 +70,16 @@ class Dialog(Window):
         if not self.proxy_is_active:
             self.activate_proxy()
         return self.proxy.exec_()
+
+    def open(self):
+        """ Launch the dialog as a modal window.
+
+        """
+        if not self.is_initialized:
+            self.initialize()
+        if not self.proxy_is_active:
+            self.activate_proxy()
+        return self.proxy.open()
 
     def done(self, result):
         """ Close the dialog and set the result value.


### PR DESCRIPTION
Add a non-blocking 'open' to Dialog so that applications may continue to run their existing event loops while the dialog is open.
Applications that wish to receive results from the Dialog can do so via the existing 'finished' event.