### PR TITLE
Move standard_tracer's subscription observer to cpp

### DIFF
--- a/enaml/core/standard_tracer.py
+++ b/enaml/core/standard_tracer.py
@@ -9,50 +9,7 @@ from atom.api import Atom, atomref
 
 from .alias import Alias
 from .code_tracing import CodeTracer
-
-
-class SubscriptionObserver(object):
-    """ An observer object which manages a tracer subscription.
-
-    """
-    __slots__ = ('ref', 'name')
-
-    def __init__(self, owner, name):
-        """ Initialize a SubscriptionObserver.
-
-        Parameters
-        ----------
-        owner : Declarative
-            The declarative owner of interest.
-
-        name : string
-            The name to which the operator is bound.
-
-        """
-        self.ref = atomref(owner)
-        self.name = name
-
-    def __bool__(self):
-        """ The notifier is valid when it has an internal owner.
-
-        The atom observer mechanism will remove the observer when it
-        tests boolean False.
-
-        """
-        return bool(self.ref)
-
-    def __call__(self, change):
-        """ The handler for the change notification.
-
-        This will be invoked by the Atom observer mechanism when the
-        item which is being observed changes.
-
-        """
-        if self.ref:
-            owner = self.ref()
-            engine = owner._d_engine
-            if engine is not None:
-                engine.update(owner, self.name)
+from .subscription_observer import SubscriptionObserver
 
 
 class StandardTracer(CodeTracer):

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -125,13 +125,13 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
         cppy::ptr engine( owner.getattr("_d_engine") );
         if ( !engine.is_none() )
         {
-            cppy::ptr args( PyTuple_New( 2 ) );
-            if( !args )
+            cppy::ptr update_args( PyTuple_New( 2 ) );
+            if( !update_args )
                 return 0;
-            PyTuple_SET_ITEM( args.get(), 0, cppy::incref( owner.get() ) );
-            PyTuple_SET_ITEM( args.get(), 1, cppy::incref( self->name ) );
+            PyTuple_SET_ITEM( update_args.get(), 0, cppy::incref( owner.get() ) );
+            PyTuple_SET_ITEM( update_args.get(), 1, cppy::incref( self->name ) );
             cppy::ptr update( engine.getattr( "update" ) );
-            return update.call( args );
+            return update.call( update_args );
         }
     }
     Py_RETURN_NONE;

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -129,9 +129,15 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
             return 0;
         if ( !engine.is_none() )
         {
-            PyObject* call_args[] = { engine.get(), owner.get(), self->name };
-            size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-            return PyObject_VectorcallMethod(update_str.get(), call_args, nargsf, 0);
+            cppy::ptr update_args( PyTuple_New( 2 ) );
+            if( !update_args )
+                return 0;
+            PyTuple_SET_ITEM( update_args.get(), 0, cppy::incref( owner.get() ) );
+            PyTuple_SET_ITEM( update_args.get(), 1, cppy::incref( self->name ) );
+            cppy::ptr update( engine.getattr( update_str.get() ) );
+            if ( !update )
+                return 0;
+            return update.call( update_args );
         }
     }
     Py_RETURN_NONE;

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -142,28 +142,6 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
 }
 
 
-PyObject*
-SubscriptionObserver_richcompare( SubscriptionObserver* self, PyObject* other, int opid )
-{
-    if( opid == Py_EQ )
-    {
-        if( SubscriptionObserver::TypeCheck( other ) )
-        {
-            SubscriptionObserver* so_other = reinterpret_cast<SubscriptionObserver*>( other );
-            if(
-                PyObject_RichCompareBool( self->atomref, so_other->atomref, Py_EQ )
-                && PyObject_RichCompareBool( self->name, so_other->name, Py_EQ )
-            )
-            {
-                Py_RETURN_TRUE;
-            }
-        }
-        Py_RETURN_FALSE;
-    }
-    Py_RETURN_NOTIMPLEMENTED;
-}
-
-
 PyDoc_STRVAR(SubscriptionObserver__doc__,
     "SubscriptionObserver(owner, name)\n\n"
     "An observer object which manages a tracer subscription.\n"
@@ -215,7 +193,6 @@ static PyType_Slot SubscriptionObserver_Type_slots[] = {
     { Py_tp_clear, void_cast( SubscriptionObserver_clear ) },              /* tp_clear */
     { Py_tp_call, void_cast( SubscriptionObserver_call ) },                /* tp_call */
     { Py_tp_doc, cast_py_tp_doc( SubscriptionObserver__doc__ ) },          /* tp_doc */
-    { Py_tp_richcompare, void_cast( SubscriptionObserver_richcompare ) },  /* tp_richcompare */
     { Py_nb_bool, void_cast( SubscriptionObserver__bool__ ) },             /* nb_bool */
     { Py_tp_getset, void_cast( SubscriptionObserver_getset ) },            /* tp_getset */
     { Py_tp_new, void_cast( SubscriptionObserver_new ) },                  /* tp_new */

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -21,6 +21,9 @@
 namespace enaml
 {
 
+// ptr to atom.api.atomref
+static cppy::ptr atomref;
+
 // POD struct - all member fields are considered private
 struct SubscriptionObserver
 {
@@ -59,19 +62,6 @@ SubscriptionObserver_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
         return 0;
     }
     SubscriptionObserver* self = reinterpret_cast<SubscriptionObserver*>( ptr.get() );
-
-    cppy::ptr atom_api( PyImport_ImportModule("atom.api") );
-    if ( !atom_api )
-    {
-        PyErr_SetString( PyExc_ImportError, "Could not import atom.api" );
-        return 0;
-    }
-    cppy::ptr atomref( atom_api.getattr("atomref") );
-    if ( !atomref )
-    {
-        PyErr_SetString( PyExc_ImportError, "Could not import atom.api.atomref" );
-        return 0;
-    }
 
     self->atomref = PyObject_CallOneArg(atomref.get(), owner);
     if( !self->atomref )
@@ -277,6 +267,19 @@ namespace
     {
         if( !SubscriptionObserver::Ready() )
         {
+            return -1;
+        }
+
+        cppy::ptr atom_api( PyImport_ImportModule("atom.api") );
+        if ( !atom_api )
+        {
+            PyErr_SetString( PyExc_ImportError, "Could not import atom.api" );
+            return -1;
+        }
+        atomref.set( atom_api.getattr("atomref") );
+        if ( !atomref )
+        {
+            PyErr_SetString( PyExc_ImportError, "Could not import atom.api.atomref" );
             return -1;
         }
 

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -129,15 +129,9 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
             return 0;
         if ( !engine.is_none() )
         {
-            cppy::ptr update_args( PyTuple_New( 2 ) );
-            if( !update_args )
-                return 0;
-            PyTuple_SET_ITEM( update_args.get(), 0, cppy::incref( owner.get() ) );
-            PyTuple_SET_ITEM( update_args.get(), 1, cppy::incref( self->name ) );
-            cppy::ptr update( engine.getattr( update_str ) );
-            if ( !update )
-                return 0;
-            return update.call( update_args );
+            PyObject* call_args[] = { engine.get(), owner.get(), self->name };
+            size_t nargsf = 3 | PY_VECTORCALL_ARGUMENTS_OFFSET;
+            return PyObject_VectorcallMethod(update_str, call_args, nargsf, 0);
         }
     }
     Py_RETURN_NONE;

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -28,7 +28,7 @@ static cppy::ptr atomref;
 struct SubscriptionObserver
 {
     PyObject_HEAD
-    PyObject* atomref;
+    PyObject* ref;
     PyObject* name;
 
     static PyType_Spec TypeObject_Spec;
@@ -63,8 +63,8 @@ SubscriptionObserver_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
     }
     SubscriptionObserver* self = reinterpret_cast<SubscriptionObserver*>( ptr.get() );
 
-    self->atomref = PyObject_CallOneArg(atomref.get(), owner);
-    if( !self->atomref )
+    self->ref = PyObject_CallOneArg(atomref.get(), owner);
+    if( !self->ref )
     {
         return 0;
     }
@@ -76,7 +76,7 @@ SubscriptionObserver_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 void
 SubscriptionObserver_clear( SubscriptionObserver* self )
 {
-    Py_CLEAR( self->atomref );
+    Py_CLEAR( self->ref );
     Py_CLEAR( self->name );
 }
 
@@ -84,7 +84,7 @@ SubscriptionObserver_clear( SubscriptionObserver* self )
 int
 SubscriptionObserver_traverse( SubscriptionObserver* self, visitproc visit, void* arg )
 {
-    Py_VISIT( self->atomref );
+    Py_VISIT( self->ref );
     return 0;
 }
 
@@ -101,7 +101,7 @@ SubscriptionObserver_dealloc( SubscriptionObserver* self )
 int
 SubscriptionObserver__bool__( SubscriptionObserver* self )
 {
-    return PyObject_IsTrue( self->atomref );
+    return PyObject_IsTrue( self->ref );
 }
 
 
@@ -117,9 +117,9 @@ PyObject*
 SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject* kwargs )
 {
 
-    if( PyObject_IsTrue( self->atomref ) )
+    if( PyObject_IsTrue( self->ref ) )
     {
-        cppy::ptr owner( PyObject_CallNoArgs( self->atomref ) );
+        cppy::ptr owner( PyObject_CallNoArgs( self->ref ) );
         if ( !owner )
             return 0;
         cppy::ptr engine( owner.getattr("_d_engine") );
@@ -156,7 +156,7 @@ PyDoc_STRVAR(SubscriptionObserver__doc__,
 PyObject*
 SubscriptionObserver_get_ref( SubscriptionObserver* self, void* context )
 {
-    return cppy::incref( self->atomref );
+    return cppy::incref( self->ref );
 }
 
 
@@ -165,7 +165,7 @@ SubscriptionObserver_set_ref( SubscriptionObserver* self, PyObject* value, void*
 {
     if( value != Py_None )
         return cppy::type_error("ref can only be set to None");
-    cppy::replace( &self->atomref, Py_None );
+    cppy::replace( &self->ref, Py_None );
     return 0;
 }
 

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -1,0 +1,335 @@
+/*-----------------------------------------------------------------------------
+ * | Copyright (c) 2025, Nucleic Development Team.
+ * |
+ * | Distributed under the terms of the Modified BSD License.
+ * |
+ * | The full license is in the file LICENSE, distributed with this software.
+ * |----------------------------------------------------------------------------*/
+#include <iostream>
+#include <sstream>
+#include <cppy/cppy.h>
+
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wdeprecated-writable-strings"
+#endif
+
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+#endif
+
+
+namespace enaml
+{
+
+// POD struct - all member fields are considered private
+struct SubscriptionObserver
+{
+    PyObject_HEAD
+    PyObject* atomref;
+    PyObject* name;
+
+    static PyType_Spec TypeObject_Spec;
+
+    static PyTypeObject* TypeObject;
+
+    static bool Ready();
+
+    static bool TypeCheck( PyObject* ob );
+
+};
+
+
+namespace
+{
+
+
+PyObject*
+SubscriptionObserver_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
+{
+    PyObject* owner;
+    PyObject* name;
+    static char* kwlist[] = { "owner", "name", 0 };
+    if( !PyArg_ParseTupleAndKeywords( args, kwargs, "OU", kwlist, &owner, &name ) )
+    {
+        return 0;
+    }
+    cppy::ptr ptr( PyType_GenericNew( type, args, kwargs ) );
+    if( !ptr )
+    {
+        return 0;
+    }
+    SubscriptionObserver* self = reinterpret_cast<SubscriptionObserver*>( ptr.get() );
+
+    cppy::ptr atom_api( PyImport_ImportModule("atom.api") );
+    if ( !atom_api )
+    {
+        PyErr_SetString( PyExc_ImportError, "Could not import atom.api" );
+        return 0;
+    }
+    cppy::ptr atomref( atom_api.getattr("atomref") );
+    if ( !atomref )
+    {
+        PyErr_SetString( PyExc_ImportError, "Could not import atom.api.atomref" );
+        return 0;
+    }
+
+    self->atomref = PyObject_CallOneArg(atomref.get(), owner);
+    if( !self->atomref )
+    {
+        return 0;
+    }
+    self->name =  cppy::incref( name );
+    return ptr.release();
+}
+
+
+void
+SubscriptionObserver_clear( SubscriptionObserver* self )
+{
+    Py_CLEAR( self->atomref );
+    Py_CLEAR( self->name );
+}
+
+
+int
+SubscriptionObserver_traverse( SubscriptionObserver* self, visitproc visit, void* arg )
+{
+    Py_VISIT( self->atomref );
+    Py_VISIT( self->name );
+    #if PY_VERSION_HEX >= 0x03090000
+    // This was not needed before Python 3.9 (Python issue 35810 and 40217)
+    Py_VISIT(Py_TYPE(self));
+    #endif
+    return 0;
+}
+
+
+void
+SubscriptionObserver_dealloc( SubscriptionObserver* self )
+{
+    PyObject_GC_UnTrack( self );
+    SubscriptionObserver_clear( self );
+    Py_TYPE(self)->tp_free( reinterpret_cast<PyObject*>( self ) );
+}
+
+
+int
+SubscriptionObserver__bool__( SubscriptionObserver* self )
+{
+    cppy::ptr atomrefptr( cppy::incref( self->atomref ) );
+    return atomrefptr.is_truthy();
+}
+
+
+/*
+ * Calls engine update with the owner and name
+ * if self.ref:
+ *     owner = self.ref()
+ *     engine = owner._d_engine
+ *      if engine is not None:
+ *         engine.update(owner, self.name)
+ */
+PyObject*
+SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject* kwargs )
+{
+
+    cppy::ptr atomrefptr( cppy::incref( self->atomref ) );
+    if( atomrefptr.is_truthy() )
+    {
+        cppy::ptr owner( PyObject_CallNoArgs( atomrefptr.get() ) );
+        cppy::ptr engine( owner.getattr("_d_engine") );
+        if ( !engine.is_none() )
+        {
+            cppy::ptr args( PyTuple_New( 2 ) );
+            if( !args )
+                return 0;
+            PyTuple_SET_ITEM( args.get(), 0, cppy::incref( owner.get() ) );
+            PyTuple_SET_ITEM( args.get(), 1, cppy::incref( self->name ) );
+            cppy::ptr update( engine.getattr( "update" ) );
+            return update.call( args );
+        }
+    }
+    Py_RETURN_NONE;
+}
+
+
+PyObject*
+SubscriptionObserver_richcompare( SubscriptionObserver* self, PyObject* other, int opid )
+{
+    if( opid == Py_EQ )
+    {
+        if( SubscriptionObserver::TypeCheck( other ) )
+        {
+            SubscriptionObserver* so_other = reinterpret_cast<SubscriptionObserver*>( other );
+            cppy::ptr sref( cppy::incref( self->atomref ) );
+            cppy::ptr sname( cppy::incref( self->name ) );
+            cppy::ptr oref( cppy::incref( so_other->atomref ) );
+            cppy::ptr oname( cppy::incref( so_other->name ) );
+            if( sref.richcmp( oref, Py_EQ ) && sname.richcmp(oname, Py_EQ ))
+            {
+                Py_RETURN_TRUE;
+            }
+        }
+        Py_RETURN_FALSE;
+    }
+    Py_RETURN_NOTIMPLEMENTED;
+}
+
+
+PyDoc_STRVAR(SubscriptionObserver__doc__,
+    "SubscriptionObserver(owner, name)\n\n"
+    "An observer object which manages a tracer subscription.\n"
+    "Parameters\n"
+    "----------\n"
+    "owner : Declarative\n"
+    "    The declarative owner of interest.\n\n"
+    "name : string\n"
+    "    The name to which the operator is bound\n");
+
+
+PyObject*
+SubscriptionObserver_get_ref( SubscriptionObserver* self, void* context )
+{
+    return cppy::incref( self->atomref );
+}
+
+
+PyObject*
+SubscriptionObserver_set_ref( SubscriptionObserver* self, PyObject* value, void* context )
+{
+    if( reinterpret_cast<PyObject*>( self ) == value )
+        return 0;
+    cppy::ptr old( self->atomref );
+    self->atomref = cppy::incref( value );
+    return 0;
+}
+
+
+PyObject*
+SubscriptionObserver_get_name( SubscriptionObserver* self, void* context )
+{
+    return cppy::incref( self->name );
+}
+
+
+static PyGetSetDef
+SubscriptionObserver_getset[] = {
+    { "ref", ( getter )SubscriptionObserver_get_ref, ( setter )SubscriptionObserver_set_ref,
+      "Get and set the ref for the observer." },
+    { "name", ( getter )SubscriptionObserver_get_name, 0,
+      "Get the name for the observer." },
+    { 0 } // sentinel
+};
+
+
+static PyType_Slot SubscriptionObserver_Type_slots[] = {
+    { Py_tp_dealloc, void_cast( SubscriptionObserver_dealloc ) },          /* tp_dealloc */
+    { Py_tp_traverse, void_cast( SubscriptionObserver_traverse) },         /* tp_traverse */
+    { Py_tp_clear, void_cast( SubscriptionObserver_clear ) },              /* tp_clear */
+    { Py_tp_call, void_cast( SubscriptionObserver_call ) },                /* tp_call */
+    { Py_tp_doc, cast_py_tp_doc( SubscriptionObserver__doc__ ) },          /* tp_doc */
+    { Py_tp_richcompare, void_cast( SubscriptionObserver_richcompare ) },  /* tp_richcompare */
+    { Py_nb_bool, void_cast( SubscriptionObserver__bool__ ) },             /* nb_bool */
+    { Py_tp_getset, void_cast( SubscriptionObserver_getset ) },            /* tp_getset */
+    { Py_tp_new, void_cast( SubscriptionObserver_new ) },                  /* tp_new */
+    { Py_tp_alloc, void_cast( PyType_GenericAlloc ) },                     /* tp_alloc */
+    { 0, 0 },
+};
+
+
+}  // namespace
+
+
+// Initialize static variables (otherwise the compiler eliminates them)
+PyTypeObject* SubscriptionObserver::TypeObject = NULL;
+
+
+PyType_Spec SubscriptionObserver::TypeObject_Spec = {
+    "enaml.core.subscription_observer.SubscriptionObserver",     /* tp_name */
+    sizeof( SubscriptionObserver ),               /* tp_basicsize */
+    0,                                   /* tp_itemsize */
+    Py_TPFLAGS_DEFAULT
+    |Py_TPFLAGS_BASETYPE
+    |Py_TPFLAGS_HAVE_GC,                 /* tp_flags */
+    SubscriptionObserver_Type_slots               /* slots */
+};
+
+
+bool SubscriptionObserver::Ready()
+{
+    // The reference will be handled by the module to which we will add the type
+    TypeObject = pytype_cast( PyType_FromSpec( &TypeObject_Spec ) );
+    if( !TypeObject )
+    {
+        return false;
+    }
+    return true;
+}
+
+
+bool SubscriptionObserver::TypeCheck( PyObject* ob )
+{
+    return PyObject_TypeCheck( ob, TypeObject ) != 0;
+}
+
+
+// Module definition
+namespace
+{
+
+
+    int
+    subscription_observer_modexec( PyObject *mod )
+    {
+        if( !SubscriptionObserver::Ready() )
+        {
+            return -1;
+        }
+
+        // subscription_observer
+        cppy::ptr subscription_observer( pyobject_cast(  SubscriptionObserver::TypeObject ) );
+        if( PyModule_AddObject( mod, "SubscriptionObserver", subscription_observer.get() ) < 0 )
+        {
+            return -1;
+        }
+        subscription_observer.release();
+
+        return 0;
+    }
+
+
+    PyMethodDef
+    subscription_observer_methods[] = {
+        { 0 } // Sentinel
+    };
+
+
+    PyModuleDef_Slot subscription_observer_slots[] = {
+        {Py_mod_exec, reinterpret_cast<void*>( subscription_observer_modexec ) },
+        {0, NULL}
+    };
+
+
+    struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        "subscription_observer",
+        "subscription_observer extension module",
+        0,
+        subscription_observer_methods,
+        subscription_observer_slots,
+        NULL,
+        NULL,
+        NULL
+    };
+
+
+}  // module namespace
+
+
+}  // namespace enaml
+
+
+PyMODINIT_FUNC PyInit_subscription_observer( void )
+{
+    return PyModuleDef_Init( &enaml::moduledef );
+}

--- a/enaml/src/subscription_observer.cpp
+++ b/enaml/src/subscription_observer.cpp
@@ -22,9 +22,9 @@ namespace enaml
 {
 
 // ptr to atom.api.atomref
-static cppy::ptr atomref;
-static cppy::ptr d_engine_str;
-static cppy::ptr update_str;
+static PyObject* atomref;
+static PyObject* d_engine_str;
+static PyObject* update_str;
 
 // POD struct - all member fields are considered private
 struct SubscriptionObserver
@@ -65,7 +65,7 @@ SubscriptionObserver_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
     }
     SubscriptionObserver* self = reinterpret_cast<SubscriptionObserver*>( ptr.get() );
 
-    self->ref = PyObject_CallOneArg(atomref.get(), owner);
+    self->ref = PyObject_CallOneArg(atomref, owner);
     if( !self->ref )
     {
         return 0;
@@ -124,7 +124,7 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
         cppy::ptr owner( PyObject_CallNoArgs( self->ref ) );
         if ( !owner )
             return 0;
-        cppy::ptr engine( owner.getattr( d_engine_str.get() ) );
+        cppy::ptr engine( owner.getattr( d_engine_str ) );
         if ( !engine )
             return 0;
         if ( !engine.is_none() )
@@ -134,7 +134,7 @@ SubscriptionObserver_call( SubscriptionObserver* self, PyObject* args, PyObject*
                 return 0;
             PyTuple_SET_ITEM( update_args.get(), 0, cppy::incref( owner.get() ) );
             PyTuple_SET_ITEM( update_args.get(), 1, cppy::incref( self->name ) );
-            cppy::ptr update( engine.getattr( update_str.get() ) );
+            cppy::ptr update( engine.getattr( update_str ) );
             if ( !update )
                 return 0;
             return update.call( update_args );
@@ -252,11 +252,11 @@ namespace
             return -1;
         }
 
-        update_str = cppy::ptr( PyUnicode_FromString("update") );
+        update_str = PyUnicode_FromString("update");
         if ( !update_str )
             return -1;
 
-        d_engine_str = cppy::ptr( PyUnicode_FromString("_d_engine") );
+        d_engine_str = PyUnicode_FromString("_d_engine");
         if ( !d_engine_str )
             return -1;
 
@@ -266,7 +266,7 @@ namespace
             PyErr_SetString( PyExc_ImportError, "Could not import atom.api" );
             return -1;
         }
-        atomref.set( atom_api.getattr("atomref") );
+        atomref = atom_api.getattr("atomref");
         if ( !atomref )
         {
             PyErr_SetString( PyExc_ImportError, "Could not import atom.api.atomref" );

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -3,6 +3,10 @@ Enaml Release Notes
 
 Dates are written as DD/MM/YYYY
 
+0.18.1 - Unreleased
+-------------------
+- Move standard_tracer's subscription observer to cpp to improve performance PR #562
+
 0.18.0 - 28/10/2024
 -------------------
 - support for Python 3.13 PR #556

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,11 @@ ext_modules = [
         ['enaml/src/declarative_function.cpp'],
         language='c++',
     ),
+    Extension(
+        'enaml.core.subscription_observer',
+        ['enaml/src/subscription_observer.cpp'],
+        language='c++',
+    ),
 ]
 
 

--- a/tests/core/test_subscription_observer.py
+++ b/tests/core/test_subscription_observer.py
@@ -1,0 +1,58 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ------------------------------------------------------------------------------
+import pytest
+from atom.api import Atom, Value
+from enaml.widgets.api import Label
+from enaml.core.subscription_observer import SubscriptionObserver
+
+
+def test_subscription_observer_ref():
+    label = Label()
+    observer = SubscriptionObserver(label, "text")
+    assert bool(observer)
+    assert observer.name == "text"
+    assert observer.ref() is label
+    observer.ref = None
+    assert not bool(observer)
+
+
+def test_subscription_observer_new():
+    label = Label()
+    with pytest.raises(TypeError):
+        observer = SubscriptionObserver(label, 0)
+
+    with pytest.raises(TypeError):
+        observer = SubscriptionObserver(None, "")
+
+
+def test_subscription_observer_compare():
+    label = Label()
+    observer = SubscriptionObserver(label, "text")
+    assert observer != SubscriptionObserver(label, "style")
+    assert observer == SubscriptionObserver(label, "text")
+
+
+def test_subscription_observer_update():
+    class Engine(Atom):
+        owner = Value()
+        name = Value()
+
+        def update(self, owner, name):
+            self.owner = owner
+            self.name = name
+
+    class Owner(Atom):
+        _d_engine = Value()
+
+    engine = Engine()
+    owner = Owner(_d_engine=engine)
+
+    observer = SubscriptionObserver(owner, "text")
+    observer()
+    assert engine.owner is owner
+    assert engine.name is "text"

--- a/tests/core/test_subscription_observer.py
+++ b/tests/core/test_subscription_observer.py
@@ -30,13 +30,6 @@ def test_subscription_observer_new():
         observer = SubscriptionObserver(None, "")
 
 
-def test_subscription_observer_compare():
-    label = Label()
-    observer = SubscriptionObserver(label, "text")
-    assert observer != SubscriptionObserver(label, "style")
-    assert observer != SubscriptionObserver(label, "text")
-
-
 def test_subscription_observer_update():
     class Engine(Atom):
         owner = Value()

--- a/tests/core/test_subscription_observer.py
+++ b/tests/core/test_subscription_observer.py
@@ -34,7 +34,7 @@ def test_subscription_observer_compare():
     label = Label()
     observer = SubscriptionObserver(label, "text")
     assert observer != SubscriptionObserver(label, "style")
-    assert observer == SubscriptionObserver(label, "text")
+    assert observer != SubscriptionObserver(label, "text")
 
 
 def test_subscription_observer_update():


### PR DESCRIPTION
Moves the subscription observer in standard_tracer.py to cpp. 

This gives a considerable performance increase if there are a lot of changes going on (~60%) but for most code it will likely only be a small improvement. My application sped up about 30% (even after fixing the original problem).

Ref https://github.com/nucleic/enaml/issues/561