### PR TITLE
Refactor declarative function and make call_func kwargs optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.un~
 *.swp
+*.kate-swp
 *.egg-info
 *.so
 *.pyd

--- a/enaml/core/standard_handlers.py
+++ b/enaml/core/standard_handlers.py
@@ -61,7 +61,7 @@ class StandardReadHandler(ReadHandler, HandlerMixin):
         f_builtins = f_globals['__builtins__']
         f_locals = self.get_locals(owner)
         scope = DynamicScope(owner, f_locals, f_globals, f_builtins)
-        return call_func(func, (), {}, scope)
+        return call_func(func, (), None, scope)
 
 
 class StandardWriteHandler(WriteHandler, HandlerMixin):
@@ -79,7 +79,7 @@ class StandardWriteHandler(WriteHandler, HandlerMixin):
         f_builtins = f_globals['__builtins__']
         f_locals = self.get_locals(owner)
         scope = DynamicScope(owner, f_locals, f_globals, f_builtins, change)
-        call_func(func, (), {}, scope)
+        call_func(func, (), None, scope)
 
 
 class StandardTracedReadHandler(ReadHandler, HandlerMixin):
@@ -98,7 +98,7 @@ class StandardTracedReadHandler(ReadHandler, HandlerMixin):
         f_locals = self.get_locals(owner)
         tr = StandardTracer(owner, name)
         scope = DynamicScope(owner, f_locals, f_globals, f_builtins, None, tr)
-        return call_func(func, (tr,), {}, scope)
+        return call_func(func, (tr,), None, scope)
 
 
 class StandardInvertedWriteHandler(WriteHandler, HandlerMixin):
@@ -117,4 +117,4 @@ class StandardInvertedWriteHandler(WriteHandler, HandlerMixin):
         f_locals = self.get_locals(owner)
         scope = DynamicScope(owner, f_locals, f_globals, f_builtins)
         inverter = StandardInverter(scope)
-        call_func(func, (inverter, change['value']), {}, scope)
+        call_func(func, (inverter, change['value']), None, scope)

--- a/tests/core/test_funchelper.py
+++ b/tests/core/test_funchelper.py
@@ -48,6 +48,21 @@ def test_handling_none_as_locals():
     assert call_func(func, (), {'a': 1}, None) == 1
 
 
+def test_handling_none_as_kewords():
+    """Test passing None as keywords.
+
+    """
+    assert call_func(func, (), None, {'a': 1}) == 1
+
+
+def test_handling_none_as_scope():
+    """Test passing None and omitting scope.
+
+    """
+    assert call_func(func, (), {'a': 1}, None) == 1
+    assert call_func(func, (), {'a': 1}, None) == 1
+
+
 def test_handling_wrong_arguments():
     """Test handling incorrect arguments.
 
@@ -61,7 +76,7 @@ def test_handling_wrong_arguments():
     assert 'tuple' in excinfo.exconly()
 
     with pytest.raises(TypeError) as excinfo:
-        call_func(func, (), None, None)
+        call_func(func, (), [], None)
     assert 'dict' in excinfo.exconly()
 
     with pytest.raises(TypeError) as excinfo:
@@ -70,4 +85,4 @@ def test_handling_wrong_arguments():
 
     with pytest.raises(TypeError) as excinfo:
         call_func(func, ())
-    assert 'must have 3 or 4 arguments' in excinfo.exconly()
+    assert 'must have 4 arguments' in excinfo.exconly()


### PR DESCRIPTION
This refactors declarative_function's Invoke to:
- use vectorcalls 
- cache the strings used
- Avoid creating empty f_locals dict 
- Avoid creating empty kwargs dict

It also slightly modifies call_func:
- require 4 arguments because I can't find any uses with 3 arguments
- allow func_kwargs to be null or None (see below). 
 
Since all standard handlers create an empty dict and pass it to kwargs that just gets checked for a dict then ignored because it is empty.  Likewise previously every dfunc call that has no kwargs was internally creating a dict just to do nothing with it in call_func. With this change the DFunc__call__'s PyObject* kwargs can be passed to call_func untouched (and if null does nothing).