### PR TITLE
import_hooks: Use cache_tag from PEP 421

### DIFF
--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -24,9 +24,7 @@ from ..compat import read_source, detect_encoding, update_code_co_filename
 
 # The magic number as symbols for the current Python interpreter. These
 # define the naming scheme used when create cached files and directories.
-MAGIC_TAG = 'enaml-py%s%s-cv%s' % (
-    sys.version_info.major, sys.version_info.minor, COMPILER_VERSION,
-)
+MAGIC_TAG = 'enaml-%s-cv%s' % (sys.implementation.cache_tag, COMPILER_VERSION)
 
 CACHEDIR = '__enamlcache__'
 


### PR DESCRIPTION
Using the cache_tag from sys.implementation over manually creating a similar tag has the advantage, that it can correctly distinguishes between different python implementations.