### PR TITLE
Update Alias ext

### DIFF
--- a/enaml/src/alias.cpp
+++ b/enaml/src/alias.cpp
@@ -51,7 +51,7 @@ Alias_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
     PyObject* target;
     PyObject* chain;
     PyObject* key;
-    if( !PyArg_ParseTuple( args, "OOO", &target, &chain, &key ) )
+    if( !PyArg_ParseTuple( args, "UOO", &target, &chain, &key ) )
         return 0;
     if( !PyTuple_CheckExact( chain ) )
         return cppy::type_error( "argument 2 must be a tuple" );
@@ -70,10 +70,12 @@ Alias_new( PyTypeObject* type, PyObject* args, PyObject* kwargs )
 void
 Alias_dealloc( Alias* self )
 {
+    PyTypeObject *tp = Py_TYPE(self);
     Py_CLEAR( self->target );
     Py_CLEAR( self->chain );
     Py_CLEAR( self->key );
-    Py_TYPE(self)->tp_free( pyobject_cast( self ) );
+    tp->tp_free( pyobject_cast( self ) );
+    Py_DECREF(tp);
 }
 
 
@@ -325,7 +327,7 @@ namespace
 int
 alias_modexec( PyObject *mod )
 {
-    storage_str = PyUnicode_FromString( "_d_storage" );
+    storage_str = PyUnicode_InternFromString( "_d_storage" );
     if( !storage_str )
     {
         return -1;  // LCOV_EXCL_LINE (failed str creation)

--- a/tests/core/test_alias.py
+++ b/tests/core/test_alias.py
@@ -5,6 +5,9 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 #------------------------------------------------------------------------------
+import gc
+import sys
+
 from textwrap import dedent
 
 import pytest
@@ -12,6 +15,22 @@ import pytest
 from enaml.core.alias import Alias
 from utils import compile_source
 
+
+def test_alias_init_deinit():
+    """Test alias constructor """
+    rc = sys.getrefcount(Alias)
+    alias = Alias('fd', ('text', ), object())
+    del alias
+    gc.collect()
+    assert sys.getrefcount(Alias) == rc
+
+    with pytest.raises(TypeError):
+        # 1st arg must be a str
+        alias = Alias(None, ('text', ), object())
+
+    with pytest.raises(TypeError):
+        # 2nd arg must be a tuple
+        alias = Alias("fd", "text", object())
 
 def test_alias_attributes():
     """Test accessing an alias attributes.


### PR DESCRIPTION
- Adds decref of typeobj 
- Makes storage_str use interned
- Changes first arg (target) to only accept a str

The key, and items in the chain should be probably also be type checked to ensure it is ok to not use GC?