### PR TITLE
Update dynamicscope

### DIFF
--- a/enaml/src/dynamicscope.cpp
+++ b/enaml/src/dynamicscope.cpp
@@ -142,16 +142,8 @@ maybe_translate_key_error()
 inline bool
 run_tracer( PyObject* tracer, PyObject* owner, PyObject* name, PyObject* value )
 {
-    cppy::ptr handler( PyObject_GetAttr( tracer, dynamic_load_str ) );
-    if( !handler )
-        return false;
-    cppy::ptr args( PyTuple_New( 3 ) );
-    if( !args )
-        return false;
-    PyTuple_SET_ITEM( args.get(), 0, cppy::incref( owner ) );
-    PyTuple_SET_ITEM( args.get(), 1, cppy::incref( name ) );
-    PyTuple_SET_ITEM( args.get(), 2, cppy::incref( value ) );
-    cppy::ptr res( handler.call( args ) );
+    PyObject* args[] = {tracer, owner, name, value};
+    cppy::ptr res( PyObject_VectorcallMethod( dynamic_load_str, args, 4 | PY_VECTORCALL_ARGUMENTS_OFFSET, 0) );
     if( !res )
         return false;
     return true;
@@ -325,10 +317,7 @@ Nonlocals_traverse( Nonlocals* self, visitproc visit, void* arg )
 {
     Py_VISIT( self->owner );
     Py_VISIT( self->tracer );
-#if PY_VERSION_HEX >= 0x03090000
-    // This was not needed before Python 3.9 (Python issue 35810 and 40217)
     Py_VISIT(Py_TYPE(self));
-#endif
     return 0;
 }
 
@@ -336,9 +325,11 @@ Nonlocals_traverse( Nonlocals* self, visitproc visit, void* arg )
 void
 Nonlocals_dealloc( Nonlocals* self )
 {
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack( self );
     Nonlocals_clear( self );
-    Py_TYPE(self)->tp_free( pyobject_cast( self ) );
+    tp->tp_free( pyobject_cast( self ) );
+    Py_DECREF(tp);
 }
 
 
@@ -382,12 +373,11 @@ Nonlocals_call( Nonlocals* self, PyObject* args, PyObject* kwargs )
         return 0;
     }
     PyObject* res = PyType_GenericNew( Py_TYPE(self), 0, 0 );
-    if( res )
-    {
-        Nonlocals* nl = reinterpret_cast<Nonlocals*>( res );
-        nl->owner = cppy::incref( objptr.get() );
-        nl->tracer = cppy::xincref( self->tracer );
-    }
+    if( !res )
+        return 0;
+    Nonlocals* nl = reinterpret_cast<Nonlocals*>( res );
+    nl->owner = cppy::incref( objptr.get() );
+    nl->tracer = cppy::xincref( self->tracer );
     return res;
 }
 
@@ -576,10 +566,7 @@ DynamicScope_traverse( DynamicScope* self, visitproc visit, void* arg )
     Py_VISIT( self->f_builtins );
     Py_VISIT( self->f_writes );
     Py_VISIT( self->f_nonlocals );
-#if PY_VERSION_HEX >= 0x03090000
-    // This was not needed before Python 3.9 (Python issue 35810 and 40217)
     Py_VISIT(Py_TYPE(self));
-#endif
     return 0;
 }
 
@@ -587,9 +574,11 @@ DynamicScope_traverse( DynamicScope* self, visitproc visit, void* arg )
 void
 DynamicScope_dealloc( DynamicScope* self )
 {
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack( self );
     DynamicScope_clear( self );
-    Py_TYPE(self)->tp_free( pyobject_cast( self ) );
+    tp->tp_free( pyobject_cast( self ) );
+    Py_DECREF(tp);
 }
 
 
@@ -609,16 +598,20 @@ DynamicScope_getitem( DynamicScope* self, PyObject* key )
             return cppy::incref( res );
     }
 
+    const char* key_data = PyUnicode_AsUTF8(key);
+    if ( !key_data )
+        return 0;
+
     // 'self' magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "self" ) == 0 )
+    if( strcmp( key_data, "self" ) == 0 )
         return cppy::incref( self->owner );
 
     // 'change' magic
-    if( self->change && strcmp( (char *)PyUnicode_AsUTF8( key ), "change" ) == 0 )
+    if( self->change && strcmp( key_data, "change" ) == 0 )
         return cppy::incref( self->change );
 
     // 'nonlocals' magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "nonlocals" ) == 0 )
+    if( strcmp( key_data, "nonlocals" ) == 0 )
     {
         if( !self->f_nonlocals )
         {
@@ -633,11 +626,11 @@ DynamicScope_getitem( DynamicScope* self, PyObject* key )
     }
 
     // __scope__ magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "__scope__" ) == 0 )
+    if( strcmp( key_data, "__scope__" ) == 0 )
         return cppy::incref( pyobject_cast( self ) );
 
     // _[tracer] magic
-    if( self->tracer && strcmp( (char *)PyUnicode_AsUTF8( key ), "_[tracer]" ) == 0 )
+    if( self->tracer && strcmp( key_data, "_[tracer]" ) == 0 )
         return cppy::incref( pyobject_cast( self->tracer ) );
 
     // value from the local scope
@@ -672,16 +665,11 @@ DynamicScope_getitem( DynamicScope* self, PyObject* key )
 }
 
 PyObject*
-DynamicScope_get( DynamicScope* self, PyObject* args)
+DynamicScope_get( DynamicScope* self, PyObject*const *args, Py_ssize_t n )
 {
-    PyObject *key;
-    PyObject *default_value = NULL;
-
-    if ( !PyArg_ParseTuple(args, "O|O", &key, &default_value) )
-    {
-        return 0;
-    }
-
+    if( n < 1 || n > 2 )
+        return cppy::type_error( "signature is get(key, default=None)" );
+    PyObject* key = args[0];
     PyObject* res = DynamicScope_getitem(self, key);
     if ( res )
     {
@@ -697,11 +685,7 @@ DynamicScope_get( DynamicScope* self, PyObject* args)
         PyErr_Clear();
     }
 
-    if ( !default_value )
-    {
-        Py_RETURN_NONE;
-    }
-    return cppy::incref( default_value );
+    return cppy::incref( n == 2 ? args[1] : Py_None );
 }
 
 int
@@ -737,29 +721,32 @@ DynamicScope_contains( DynamicScope* self, PyObject* key )
         cppy::type_error( key, "str" );
         return -1;
     }
-
     // value from the override scope
     if( self->f_writes && PyDict_GetItem( self->f_writes, key ) )
         return 1;
 
+    const char* key_data = PyUnicode_AsUTF8(key);
+    if ( !key_data )
+        return 0;
+
     // 'self' magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "self" ) == 0 )
+    if( strcmp( key_data, "self") == 0 )
         return 1;
 
     // 'change' magic
-    if( self->change && strcmp( (char *)PyUnicode_AsUTF8( key ), "change" ) == 0 )
+    if( self->change && strcmp( key_data, "change" ) == 0 )
         return 1;
 
     // 'nonlocals' magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "nonlocals" ) == 0 )
+    if( strcmp( key_data, "nonlocals" ) == 0 )
         return 1;
 
     // __scope__ magic
-    if( strcmp( (char *)PyUnicode_AsUTF8( key ), "__scope__" ) == 0 )
+    if( strcmp( key_data, "__scope__" ) == 0 )
         return 1;
 
     // _[tracer] magic
-    if( self->tracer && strcmp( (char *)PyUnicode_AsUTF8( key ), "_[tracer]" ) == 0 )
+    if( self->tracer && strcmp( key_data, "_[tracer]" ) == 0 )
         return 1;
 
     // value from the local scope
@@ -833,7 +820,7 @@ DynamicScope_getset[] = {
 
 
 static PyMethodDef DynamicScope_methods[] = {
-    {"get",    reinterpret_cast<PyCFunction>(DynamicScope_get), METH_VARARGS, ""},
+    {"get",    reinterpret_cast<PyCFunction>(DynamicScope_get), METH_FASTCALL, ""},
     { 0 }  // Sentinel
 };
 
@@ -891,12 +878,12 @@ namespace
 int
 dynamicscope_modexec( PyObject *mod )
 {
-    parent_str = PyUnicode_FromString( "_parent" );
+    parent_str = PyUnicode_InternFromString( "_parent" );
     if( !parent_str )
     {
         return -1;  // LCOV_EXCL_LINE (failed to create string)
     }
-    dynamic_load_str = PyUnicode_FromString( "dynamic_load" );
+    dynamic_load_str = PyUnicode_InternFromString( "dynamic_load" );
     if( !dynamic_load_str )
     {
         return -1;  // LCOV_EXCL_LINE (failed to create string)
@@ -924,7 +911,8 @@ dynamicscope_modexec( PyObject *mod )
 	}
     dynamicscope.release();
 
-    PyModule_AddObject( mod, "UserKeyError", UserKeyError );
+    if( PyModule_AddObjectRef( mod, "UserKeyError", UserKeyError ) < 0 )
+        return -1; // LCOV_EXCL_LINE (failed to add to module)
 
     return 0;
 }


### PR DESCRIPTION
This addresses the recent issues, changes run_tracer and Dynamicscope_get to use a vectorcall, and makes all the magics use interned strings. 

In a simple benchmark (updating a local and global counter within a clicked block) I see about a 10% speedup.