### PR TITLE
Drop dead PY311 branches missed by copilot

### DIFF
--- a/enaml/compat.py
+++ b/enaml/compat.py
@@ -10,8 +10,6 @@ import re
 import codecs
 import tokenize
 
-PY311 = sys.version_info >= (3, 11)
-
 PY312 = sys.version_info >= (3, 12)
 
 PY313 = sys.version_info >= (3, 13)

--- a/enaml/core/block_compiler.py
+++ b/enaml/core/block_compiler.py
@@ -9,7 +9,7 @@ from atom.api import Typed
 
 from . import compiler_common as cmn
 from .enaml_ast import TemplateInst, ChildDef
-from ..compat import PY311, PY313
+from ..compat import PY313
 
 
 class BaseBlockCompiler(cmn.CompilerBase):
@@ -140,7 +140,7 @@ class SecondPassBlockCompiler(BaseBlockCompiler):
             index = self.index_map[node]
             # Python 3.11 and 3.12 requires a NULL before a function that is not a method
             # Python 3.13 one after
-            if not PY313 and PY311:
+            if not PY313:
                 cg.push_null()
             cmn.load_helper(cg, 'make_unpack_map')
             if PY313:

--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import bytecode as bc
 from atom.api import Atom, Bool, Int, List, Str
 
-from ..compat import PY311, PY312, PY313, PY314
+from ..compat import PY312, PY313, PY314
 
 
 class _ReturnNoneIdentifier(ast.NodeVisitor):
@@ -118,12 +118,11 @@ class CodeGenerator(Atom):
                 bc_code.flags ^= bc_code.flags & flag
         bc_code.update_flags()
         # Ensure all code objects starts with a RESUME to get the right frame
-        if PY311:
-            for i, instr in enumerate(bc_code):
-                if isinstance(instr, bc.Instr):
-                    if instr.name != "RESUME":
-                        bc_code.insert(i, bc.Instr("RESUME", 0))
-                    break
+        for i, instr in enumerate(bc_code):
+            if isinstance(instr, bc.Instr):
+                if instr.name != "RESUME":
+                    bc_code.insert(i, bc.Instr("RESUME", 0))
+                break
 
         return bc_code.to_code()
 
@@ -135,12 +134,8 @@ class CodeGenerator(Atom):
 
     def load_global(self, name, push_null=False):
         """Load a global variable onto the TOS."""
-        if PY311:
-            args = (push_null, name)
-        else:
-            args = name
         self.code_ops.append(  # TOS
-            bc.Instr("LOAD_GLOBAL", args),  # TOS -> value
+            bc.Instr("LOAD_GLOBAL", (push_null, name)),  # TOS -> value
         )
 
     def load_name(self, name):
@@ -244,32 +239,20 @@ class CodeGenerator(Atom):
 
     def binary_multiply(self):
         """Multiply the 2 items on the TOS."""
-        if PY311:
-            instr = bc.Instr("BINARY_OP", 5)
-        else:
-            instr = bc.Instr("BINARY_MULTIPLY")
         self.code_ops.append(  # TOS -> val_1 -> val_2
-            instr,  # TOS -> retval
+            bc.Instr("BINARY_OP", 5),  # TOS -> retval
         )
 
     def binary_add(self):
         """Add the 2 items on the TOS."""
-        if PY311:
-            instr = bc.Instr("BINARY_OP", 0)
-        else:
-            instr = bc.Instr("BINARY_ADD")
         self.code_ops.append(  # TOS -> val_1 -> val_2
-            instr,  # TOS -> retval
+            bc.Instr("BINARY_OP", 0),  # TOS -> retval
         )
 
     def dup_top(self):
         """Duplicate the value on the TOS."""
-        if PY311:
-            instr = bc.Instr("COPY", 1)
-        else:
-            instr = bc.Instr("DUP_TOP")
         self.code_ops.append(  # TOS -> value
-            instr,  # TOS -> value -> value
+            bc.Instr("COPY", 1),  # TOS -> value -> value
         )
 
     def build_map(self, n=0):
@@ -316,8 +299,6 @@ class CodeGenerator(Atom):
 
     def make_function(self, flags=0, name=None):
         """Make a function from a code object on the TOS."""
-        if not PY311:
-            self.load_const(name)
         if PY313:
             if flags:
                 self.code_ops.extend(
@@ -349,7 +330,7 @@ class CodeGenerator(Atom):
             # TOS -> func -> null -> args -> kwargs_names -> kwargs (tuple)
             arg = n_args + n_kwds
             self.code_ops.append(bc.Instr("CALL_KW" if n_kwds else "CALL", arg))
-        elif PY311:
+        else:
             # NOTE: In Python 3.11 the caller must push null
             # onto the stack before calling this
             # TOS -> null -> func -> args -> kwargs -> kwargs_names
@@ -361,21 +342,6 @@ class CodeGenerator(Atom):
             if n_kwds:
                 ops.insert(0, bc.Instr("KW_NAMES", 3))
             self.code_ops.extend(ops)
-        else:
-            if n_kwds:
-                if is_method:
-                    raise ValueError(
-                        "Method calling convention cannot be used with keywords"
-                    )
-                # kwargs_name should be a tuple listing the keyword
-                # arguments names
-                # TOS -> func -> args -> kwargs -> kwargs_names
-                op, arg = "CALL_FUNCTION_KW", n_args + n_kwds
-            elif is_method:
-                op, arg = "CALL_METHOD", n_args
-            else:
-                op, arg = "CALL_FUNCTION", n_args
-            self.code_ops.append(bc.Instr(op, arg))  # TOS -> retval
 
     def call_function_var(self, kwds: bool = False):
         """Call a variadic function on the TOS with the given args and kwargs."""
@@ -402,27 +368,18 @@ class CodeGenerator(Atom):
 
     def rot_two(self):
         """Rotate the two values on the TOS."""
-        if PY311:
-            instr = bc.Instr("SWAP", 2)
-        else:
-            instr = bc.Instr("ROT_TWO")
         self.code_ops.append(  # TOS -> val_1 -> val_2
-            instr,  # TOS -> val_2 -> val_1
+            bc.Instr("SWAP", 2),  # TOS -> val_2 -> val_1
         )
 
     def rot_three(self):
         """Rotate the three values on the TOS."""
-        if PY311:
-            self.code_ops.extend(
-                (  # TOS -> val_1 -> val_2 -> val_3
-                    bc.Instr("SWAP", 3),  # TOS -> val_3 -> val_2 -> val_1
-                    bc.Instr("SWAP", 2),  # TOS -> val_3 -> val_1 -> val_2
-                )
+        self.code_ops.extend(
+            (  # TOS -> val_1 -> val_2 -> val_3
+                bc.Instr("SWAP", 3),  # TOS -> val_3 -> val_2 -> val_1
+                bc.Instr("SWAP", 2),  # TOS -> val_3 -> val_1 -> val_2
             )
-        else:
-            self.code_ops.append(  # TOS -> val_1 -> val_2 -> val_3
-                bc.Instr("ROT_THREE")  # TOS -> val_3 -> val_1 -> val_2
-            )
+        )
 
     def unpack_sequence(self, n):
         """Unpack the sequence on the TOS."""
@@ -444,57 +401,28 @@ class CodeGenerator(Atom):
         """
         exc_label = bc.Label()
         end_label = bc.Label()
-        if PY311:
-            self.code_ops.append(tb := bc.TryBegin(exc_label, False))
-            first_new = len(self.code_ops)
-            yield
-            for i in self.code_ops[first_new:]:
-                if isinstance(i, bc.TryBegin):
-                    raise ValueError(
-                        "try_squash_raise cannot wrap a block containing "
-                        "exception handling logic. Wrapped block is:\n"
-                        f"{self.code_ops[first_new:]}"
-                    )
-            ops = [
-                bc.TryEnd(tb),
-                bc.Instr("JUMP_FORWARD", end_label),
-                # Under Python 3.11 only the actual exception is pushed
-                exc_label,  # TOS -> val
-                bc.Instr("LOAD_CONST", None),  # TOS -> val -> None
-                bc.Instr("COPY", 2),  # TOS -> val -> None -> val
-                bc.Instr("STORE_ATTR", "__traceback__"),  # TOS -> val
-                bc.Instr("RAISE_VARARGS", 1),
-                end_label,
-            ]
-            self.code_ops.extend(ops)
-        else:
-            op_code = "SETUP_FINALLY"
-            self.code_ops.append(
-                bc.Instr(op_code, exc_label),  # TOS
-            )
-            yield
-            # exc is only the exception type which can be used for matching
-            # val is the exception value, raising it directly preserve the traceback
-            # tb is the traceback and is of little interest
-            # We reset the traceback to None to make it appear as if the code
-            # raised the exception instead of a function called by it
-            ops = [  # TOS
-                bc.Instr("POP_BLOCK"),  # TOS
-                bc.Instr("JUMP_FORWARD", end_label),  # TOS
-                exc_label,  # TOS -> tb -> val -> exc
-                bc.Instr("POP_TOP"),  # TOS -> tb -> val
-                bc.Instr("ROT_TWO"),  # TOS -> val -> tb
-                bc.Instr("POP_TOP"),  # TOS -> val
-                bc.Instr("DUP_TOP"),  # TOS -> val -> val
-                bc.Instr("LOAD_CONST", None),  # TOS -> val -> val -> None
-                bc.Instr("ROT_TWO"),  # TOS -> val -> None -> val
-                bc.Instr("STORE_ATTR", "__traceback__"),  # TOS -> val
-                bc.Instr("RAISE_VARARGS", 1),  # TOS
-                bc.Instr("POP_EXCEPT"),
-                bc.Instr("JUMP_FORWARD", end_label),  # TOS
-                end_label,  # TOS
-            ]
-            self.code_ops.extend(ops)
+        self.code_ops.append(tb := bc.TryBegin(exc_label, False))
+        first_new = len(self.code_ops)
+        yield
+        for i in self.code_ops[first_new:]:
+            if isinstance(i, bc.TryBegin):
+                raise ValueError(
+                    "try_squash_raise cannot wrap a block containing "
+                    "exception handling logic. Wrapped block is:\n"
+                    f"{self.code_ops[first_new:]}"
+                )
+        ops = [
+            bc.TryEnd(tb),
+            bc.Instr("JUMP_FORWARD", end_label),
+            # Under Python 3.11 only the actual exception is pushed
+            exc_label,  # TOS -> val
+            bc.Instr("LOAD_CONST", None),  # TOS -> val -> None
+            bc.Instr("COPY", 2),  # TOS -> val -> None -> val
+            bc.Instr("STORE_ATTR", "__traceback__"),  # TOS -> val
+            bc.Instr("RAISE_VARARGS", 1),
+            end_label,
+        ]
+        self.code_ops.extend(ops)
 
     @contextmanager
     def for_loop(self, iter_var, fast_var=True):
@@ -519,7 +447,7 @@ class CodeGenerator(Atom):
         self.code_ops.append(
             bc.Instr("SETUP_LOOP", end_label),
         )
-        if PY311 and not fast_var:
+        if not fast_var:
             # LOAD_GLOBAL expects a tuple on 3.11
             iter_var = (False, iter_var)
         self.code_ops.extend(
@@ -552,8 +480,8 @@ class CodeGenerator(Atom):
         _inspector.visit(pydata)
         code = compile(pydata, self.filename, mode="exec")
         bc_code = bc.Bytecode.from_code(code)
-        if PY311:  # Trim irrelevant RESUME opcode
-            bc_code = bc_code[1:]
+        # Trim irrelevant RESUME opcode
+        bc_code = bc_code[1:]
         # With a with or try statement the implicit return None can be
         # duplicated. We remove return None from all basic blocks when
         # it was not present in the AST
@@ -595,8 +523,8 @@ class CodeGenerator(Atom):
         """Insert the compiled code for a Python Expression ast or string."""
         code = compile(pydata, self.filename, mode="eval")
         bc_code = bc.Bytecode.from_code(code)
-        if PY311:  # Trim irrelevant RESUME opcode
-            bc_code = bc_code[1:]
+        # Trim irrelevant RESUME opcode
+        bc_code = bc_code[1:]
         if bc_code[-1].name == "RETURN_CONST":
             bc_code[-1] = bc.Instr(
                 "LOAD_CONST", bc_code[-1].arg, location=bc_code[-1].location
@@ -646,12 +574,10 @@ class CodeGenerator(Atom):
                     arg_names.append(i_arg)
                 elif i_arg in stored_names:
                     op = "LOAD_FAST"
-                elif PY311:
+                else:
                     # TODO: Is there a better way to do this?
                     code_ops[idx] = bc.Instr("LOAD_GLOBAL", (False, instr.arg))
                     continue
-                else:
-                    op = "LOAD_GLOBAL"
                 instr.name = op
             elif i_name == "DELETE_NAME":
                 if instr.arg in stored_names:

--- a/enaml/core/code_tracing.py
+++ b/enaml/core/code_tracing.py
@@ -8,7 +8,7 @@
 from types import CodeType
 
 import bytecode as bc
-from ..compat import PY311, PY312, PY313, PY314
+from ..compat import PY312, PY313, PY314
 
 
 class CodeTracer(object):
@@ -389,7 +389,7 @@ elif PY312:
             Instr("POP_TOP"),  # obj
         ]
 
-elif PY311:
+else:
 
     def call_tracer_load_attr(tracer_op: str, i_arg: int, Instr=bc.Instr):
         return [  # obj
@@ -462,80 +462,6 @@ elif PY311:
             Instr("COPY", 3),  # obj -> null -> tracefunc -> obj
             Instr("PRECALL", 0x0001),
             Instr("CALL", 0x0001),  # obj -> retval
-            Instr("POP_TOP"),  # obj
-        ]
-
-    def call_tracer_return_const(tracer_op: str, const, Instr=bc.Instr):
-        raise NotImplementedError()
-
-else:
-
-    def call_tracer_load_attr(tracer_op: str, i_arg: int, Instr=bc.Instr):
-        return [  # obj
-            Instr("DUP_TOP"),  # obj -> obj
-            Instr(tracer_op, "_[tracer]"),  # obj -> obj -> tracer
-            Instr("LOAD_ATTR", "load_attr"),  # obj -> obj -> tracefunc
-            Instr("ROT_TWO"),  # obj -> tracefunc -> obj
-            Instr("LOAD_CONST", i_arg),  # obj -> tracefunc -> obj -> attr
-            Instr("CALL_FUNCTION", 0x0002),  # obj -> retval
-            Instr("POP_TOP"),  # obj
-        ]
-
-    def call_tracer_call_function(tracer_op: str, i_arg: int, Instr=bc.Instr):
-        # n_stack_args = i_arg
-        return [  # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-            Instr("BUILD_TUPLE", i_arg),  # func -> argtuple
-            Instr("DUP_TOP_TWO"),  # func -> argtuple -> func -> argtuple
-            Instr(
-                tracer_op, "_[tracer]"
-            ),  # func -> argtuple -> func -> argtuple -> tracer
-            Instr(
-                "LOAD_ATTR", "call_function"
-            ),  # func -> argtuple -> func -> argtuple -> tracefunc
-            Instr("ROT_THREE"),  # func -> argtuple -> tracefunc -> func -> argtuple
-            Instr(
-                "LOAD_CONST", i_arg
-            ),  # func -> argtuple -> tracefunc -> func -> argtuple -> argspec
-            Instr("CALL_FUNCTION", 0x0003),  # func -> argtuple -> retval
-            Instr("POP_TOP"),  # func -> argtuple
-            Instr(
-                "UNPACK_SEQUENCE", i_arg
-            ),  # func -> arg(n-1) -> arg(n-2) -> ... -> arg(0)
-            Instr("BUILD_TUPLE", i_arg),  # func -> reversedargtuple
-            Instr(
-                "UNPACK_SEQUENCE", i_arg
-            ),  # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-        ]
-
-    def call_tracer_binary_subscr(tracer_op: str, Instr=bc.Instr):
-        return [  # obj -> idx
-            Instr("DUP_TOP_TWO"),  # obj -> idx -> obj -> idx
-            Instr(tracer_op, "_[tracer]"),  # obj -> idx -> obj -> idx -> tracer
-            Instr(
-                "LOAD_ATTR", "binary_subscr"
-            ),  # obj -> idx -> obj -> idx -> tracefunc
-            Instr("ROT_THREE"),  # obj -> idx -> tracefunc -> obj -> idx
-            Instr("CALL_FUNCTION", 0x0002),  # obj -> idx -> retval
-            Instr("POP_TOP"),  # obj -> idx
-        ]
-
-    def call_tracer_get_iter(tracer_op: str, Instr=bc.Instr):
-        return [  # obj
-            Instr("DUP_TOP"),  # obj -> obj
-            Instr(tracer_op, "_[tracer]"),  # obj -> obj -> tracer
-            Instr("LOAD_ATTR", "get_iter"),  # obj -> obj -> tracefunc
-            Instr("ROT_TWO"),  # obj -> tracefunc -> obj
-            Instr("CALL_FUNCTION", 0x0001),  # obj -> retval
-            Instr("POP_TOP"),  # obj
-        ]
-
-    def call_tracer_return_value(tracer_op: str, Instr=bc.Instr):
-        return [  # obj
-            Instr("DUP_TOP"),  # obj -> obj
-            Instr(tracer_op, "_[tracer]"),  # obj -> obj -> tracer
-            Instr("LOAD_ATTR", "return_value"),  # obj -> obj -> tracefunc
-            Instr("ROT_TWO"),  # obj -> tracefunc -> obj
-            Instr("CALL_FUNCTION", 0x0001),  # obj -> retval
             Instr("POP_TOP"),  # obj
         ]
 
@@ -763,7 +689,7 @@ elif PY312:
             Instr("CALL", 0x0003),  # retval
             Instr("RETURN_VALUE"),  #
         ]
-elif PY311:
+else:
 
     def call_inverter_load_name(i_arg: int, Instr=bc.Instr):
         return [
@@ -827,53 +753,6 @@ elif PY311:
             ),  # null -> invertfunc -> obj -> index -> value
             Instr("PRECALL", 0x0003),  #
             Instr("CALL", 0x0003),  # retval
-            Instr("RETURN_VALUE"),  #
-        ]
-else:
-
-    def call_inverter_load_name(i_arg: int, Instr=bc.Instr):
-        return [
-            Instr("LOAD_FAST", "_[inverter]"),  # inverter
-            Instr("LOAD_ATTR", "load_name"),  # invertfunc
-            Instr("LOAD_CONST", i_arg),  # invertfunc -> name
-            Instr("LOAD_FAST", "_[value]"),  # invertfunc -> name - > value
-            Instr("CALL_FUNCTION", 0x0002),  # retval
-            Instr("RETURN_VALUE"),  #
-        ]
-
-    def call_inverter_load_attr(i_arg: int, Instr=bc.Instr):
-        return [  # obj
-            Instr("LOAD_FAST", "_[inverter]"),  # obj -> inverter
-            Instr("LOAD_ATTR", "load_attr"),  # obj -> invertfunc
-            Instr("ROT_TWO"),  # invertfunc -> obj
-            Instr("LOAD_CONST", i_arg),  # invertfunc -> obj -> attr
-            Instr("LOAD_FAST", "_[value]"),  # invertfunc -> obj -> attr -> value
-            Instr("CALL_FUNCTION", 0x0003),  # retval
-            Instr("RETURN_VALUE"),  #
-        ]
-
-    def call_inverter_call_function(i_arg: int, Instr=bc.Instr):
-        # n_stack_args = i_arg
-        return [  # func -> arg(0) -> arg(1) -> ... -> arg(n-1)
-            Instr("BUILD_TUPLE", i_arg),  # func -> argtuple
-            Instr("LOAD_FAST", "_[inverter]"),  # func -> argtuple -> inverter
-            Instr("LOAD_ATTR", "call_function"),  # func -> argtuple -> invertfunc
-            Instr("ROT_THREE"),  # invertfunc -> func -> argtuple
-            Instr("LOAD_CONST", i_arg),  # invertfunc -> func -> argtuple -> argspec
-            Instr(
-                "LOAD_FAST", "_[value]"
-            ),  # invertfunc -> func -> argtuple -> argspec -> value
-            Instr("CALL_FUNCTION", 0x0004),  # retval
-            Instr("RETURN_VALUE"),  #
-        ]
-
-    def call_inverter_binary_subsrc(Instr=bc.Instr):
-        return [  # obj -> index
-            Instr("LOAD_FAST", "_[inverter]"),  # obj -> index -> inverter
-            Instr("LOAD_ATTR", "binary_subscr"),  # obj -> index -> invertfunc
-            Instr("ROT_THREE"),  # invertfunc -> obj -> index
-            Instr("LOAD_FAST", "_[value]"),  # invertfunc -> obj -> index -> value
-            Instr("CALL_FUNCTION", 0x0003),  # retval
             Instr("RETURN_VALUE"),  #
         ]
 

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -14,7 +14,7 @@ from types import CodeType
 import bytecode as bc
 from atom.api import Str, Typed
 
-from ..compat import PY311, PY312, PY313, PY314
+from ..compat import PY312, PY313, PY314
 from .code_generator import CodeGenerator
 from .enaml_ast import (
     AliasExpr, ASTVisitor, Binding, ChildDef, EnamlDef, StorageExpr, Template,
@@ -395,43 +395,28 @@ def analyse_globals_and_func_defs(pyast):
     return global_vars, has_def
 
 
-if PY311:
-    def rewrite_globals_access(code, global_vars: set[str]) -> None:
-        """Update the function code global loads
+def rewrite_globals_access(code, global_vars: set[str]) -> None:
+    """Update the function code global loads
 
-        This will rewrite the function to convert each LOAD_GLOBAL opcode
-        into a LOAD_NAME opcode, unless the associated name is known to have been
-        made global via the 'global' keyword.
+    This will rewrite the function to convert each LOAD_GLOBAL opcode
+    into a LOAD_NAME opcode, unless the associated name is known to have been
+    made global via the 'global' keyword.
 
-        """
-        # On Python 3.11+ if the LOAD_GLOBAL has the PUSH_NULL flag set
-        # we have re-inject that when doing the rewrite or it jacks up the stack
-        # On Python 3.13+, the NULL is loaded after the value
-        inserts = []
-        for idx, instr in enumerate(code):
-            if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
-                    instr.arg[1] not in global_vars):
-                if instr.arg[0]:
-                    inserts.append(idx)
-                code[idx] = bc.Instr("LOAD_NAME", instr.arg[1])
+    """
+    # On Python 3.11+ if the LOAD_GLOBAL has the PUSH_NULL flag set
+    # we have re-inject that when doing the rewrite or it jacks up the stack
+    # On Python 3.13+, the NULL is loaded after the value
+    inserts = []
+    for idx, instr in enumerate(code):
+        if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
+                instr.arg[1] not in global_vars):
+            if instr.arg[0]:
+                inserts.append(idx)
+            code[idx] = bc.Instr("LOAD_NAME", instr.arg[1])
 
-        # Walk backwards so indexes remain valid
-        for idx in reversed(inserts):
-            code.insert(idx + (1 if PY313 else 0), bc.Instr("PUSH_NULL"))
-
-else:
-    def rewrite_globals_access(code, global_vars: set[str]) -> None:
-        """Update the function code global loads
-
-        This will rewrite the function to convert each LOAD_GLOBAL opcode
-        into a LOAD_NAME opcode, unless the associated name is known to have been
-        made global via the 'global' keyword.
-
-        """
-        for idx, instr in enumerate(code):
-            if (getattr(instr, "name", None) == "LOAD_GLOBAL" and
-                    instr.arg not in global_vars):
-                instr.name = "LOAD_NAME"
+    # Walk backwards so indexes remain valid
+    for idx in reversed(inserts):
+        code.insert(idx + (1 if PY313 else 0), bc.Instr("PUSH_NULL"))
 
 
 def run_in_dynamic_scope(code: bc.Bytecode, global_vars: set[str]) -> None:
@@ -451,7 +436,7 @@ def run_in_dynamic_scope(code: bc.Bytecode, global_vars: set[str]) -> None:
     # Code generator used to modify the bytecode
     cg = CodeGenerator()
 
-    if PY311 and getattr(code[0], "name", None) == "RESUME":
+    if getattr(code[0], "name", None) == "RESUME":
         cg.code_ops.append(code[0])
         instrs = code[1:]
     else:
@@ -483,12 +468,11 @@ def run_in_dynamic_scope(code: bc.Bytecode, global_vars: set[str]) -> None:
             cg.rot_two()                                 # wrap -> func
             # Python 3.11 and 3.12 requires a NULL before a function that is not a method
             # Python 3.13 one after
-            if PY311:
-                cg.push_null()                           # wrap -> func -> null
-                if PY313:
-                    cg.rot_two()                         # wrap -> null -> func
-                else:
-                    cg.rot_three()                       # null -> wrap -> func
+            cg.push_null()                           # wrap -> func -> null
+            if PY313:
+                cg.rot_two()                         # wrap -> null -> func
+            else:
+                cg.rot_three()                       # null -> wrap -> func
             cg.load_global('__scope__')                  # wrap -> func -> scope
             cg.call_function(2)                          # wrapped
             continue
@@ -525,7 +509,7 @@ def gen_child_def_node(cg: CodeGenerator, node: ChildDef, local_names: set[str])
         cg.dup_top()
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
             cg.rot_two()                        # base -> null -> base
         load_helper(cg, 'validate_declarative')
@@ -542,7 +526,7 @@ def gen_child_def_node(cg: CodeGenerator, node: ChildDef, local_names: set[str])
 
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
             cg.rot_two()                        # null -> base
 
@@ -579,7 +563,7 @@ def gen_child_def_node(cg: CodeGenerator, node: ChildDef, local_names: set[str])
     # Build the declarative compiler node
     # Python 3.11 and 3.12 requires a NULL before a function that is not a method
     # Python 3.13 one after
-    if not PY313 and PY311:
+    if not PY313:
         cg.push_null()
         cg.rot_two()                            # null -> class
     store_locals = should_store_locals(node)
@@ -618,7 +602,7 @@ def gen_template_inst_node(cg: CodeGenerator, node: TemplateInst, local_names: s
         cg.dup_top()
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
             cg.rot_two()  # null -> template
         load_helper(cg, 'validate_template')
@@ -631,10 +615,9 @@ def gen_template_inst_node(cg: CodeGenerator, node: TemplateInst, local_names: s
 
     # Load the arguments for the instantiation call.
     arguments = node.arguments
-    if PY311:
-        cg.push_null()    # template -> null
-        if not PY313:
-            cg.rot_two()  # null -> template
+    cg.push_null()    # template -> null
+    if not PY313:
+        cg.rot_two()  # null -> template
 
     for arg in arguments.args:
         safe_eval_ast(cg, arg.ast, node.name, arg.lineno, local_names)
@@ -661,7 +644,7 @@ def gen_template_inst_node(cg: CodeGenerator, node: TemplateInst, local_names: s
             cg.dup_top()
             # Python 3.11 and 3.12 requires a NULL before a function that is not a method
             # Python 3.13 one after
-            if not PY313 and PY311:
+            if not PY313:
                 cg.push_null()
                 cg.rot_two()  # null -> template_inst
             load_helper(cg, 'validate_unpack_size')
@@ -677,7 +660,7 @@ def gen_template_inst_node(cg: CodeGenerator, node: TemplateInst, local_names: s
     # Load and call the helper to create the compiler node
     # Python 3.11 and 3.12 requires a NULL before a function that is not a method
     # Python 3.13 one after
-    if not PY313 and PY311:
+    if not PY313:
         cg.push_null()
         cg.rot_two()  # null -> tmpl
     load_helper(cg, 'template_inst_node')
@@ -759,7 +742,7 @@ def gen_template_inst_binding(cg: CodeGenerator, node: TemplateInstBinding, inde
         cg.set_lineno(node.lineno)
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         load_helper(cg, 'run_operator')
         if PY313:
@@ -804,7 +787,7 @@ def gen_operator_binding(cg: CodeGenerator, node, index: int, name: str) -> None
 
     with cg.try_squash_raise():
         cg.set_lineno(node.lineno)
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         load_helper(cg, 'run_operator')
         if PY313:
@@ -843,7 +826,7 @@ def gen_alias_expr(cg: CodeGenerator, node: AliasExpr, index: int) -> None:
         cg.set_lineno(node.lineno)
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         load_helper(cg, 'add_alias')
         if PY313:
@@ -881,7 +864,7 @@ def gen_storage_expr(cg: CodeGenerator, node: StorageExpr, index: int, local_nam
         cg.set_lineno(node.lineno)
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         load_helper(cg, 'add_storage')
         if PY313:
@@ -925,25 +908,18 @@ def _insert_decl_function(cg, funcdef):
 
     # the stack now looks like the following:
     #   ...
-    #   ...
-    #   LOAD_CONST      (<code object>)
-    #   LOAD_CONST      (qualified name)
-    #   MAKE_FUCTION    (flag)              // TOS
-
-    # On Python 3.11 the stack is
-    #   ...
     #   LOAD_CONST      (<code object>)
     #   MAKE_FUCTION    (flag)              // TOS
-    code_offset = -1 if PY311 else -2
 
     # Look for the MAKE_FUNCTION instruction
     # 3.13 make the exact position variable due to the possible existence of
     # a SET_FUNCTION_ATTRIBUTE
-    code_index = -1
     for index, i in enumerate(outer_ops):
         if i.name == "MAKE_FUNCTION":
             break
-    code_index = index + code_offset
+    else:
+        index = 0
+    code_index = index - 1
     assert code_index >= 0
 
     # extract the inner code object which represents the actual
@@ -986,7 +962,7 @@ def gen_decl_funcdef(cg: CodeGenerator, node: FuncDef, index: int) -> None:
         cg.set_lineno(node.lineno)
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         load_helper(cg, 'add_decl_function')
         if PY313:

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -11,7 +11,7 @@ from . import compiler_common as cmn
 from .enaml_ast import Module
 from .enamldef_compiler import EnamlDefCompiler
 from .template_compiler import TemplateCompiler
-from ..compat import PY311, PY313
+from ..compat import PY313
 
 # Increment this number whenever the compiler changes the code which it
 # generates. This number is used by the import hooks to know which version
@@ -215,7 +215,7 @@ class EnamlCompiler(cmn.CompilerBase):
     def visit_EnamlDef(self, node):
         # Invoke the enamldef code and store result in the namespace.
         cg = self.code_generator
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         code = EnamlDefCompiler.compile(node, cg.filename)
         cg.load_const(code)
@@ -232,7 +232,7 @@ class EnamlCompiler(cmn.CompilerBase):
         with cg.try_squash_raise():
             # Python 3.11 and 3.12 requires a NULL before a function that is not a method
             # Python 3.13 one after
-            if not PY313 and PY311:
+            if not PY313:
                 cg.push_null()
 
             # Load and validate the parameter specializations
@@ -241,7 +241,7 @@ class EnamlCompiler(cmn.CompilerBase):
                 if spec is not None:
                     # Python 3.11 and 3.12 requires a NULL before a function that is not a method
                     # Python 3.13 one after
-                    if not PY313 and PY311:
+                    if not PY313:
                         cg.push_null()
                     cmn.load_helper(cg, 'validate_spec', from_globals=True)
                     if PY313:

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -8,7 +8,7 @@
 from . import block_compiler as block
 from . import compiler_common as cmn
 from .enaml_ast import EnamlDef
-from ..compat import PY311, PY313
+from ..compat import PY313
 
 
 class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
@@ -83,7 +83,7 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
 
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
 
         # Preload the helper to generate the enamldef
@@ -101,7 +101,7 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
             cg.dup_top()                            # helper -> name -> base -> base
             # Python 3.11 and 3.12 requires a NULL before a function that is not a method
             # Python 3.13 one after
-            if not PY313 and PY311:
+            if not PY313:
                 cg.push_null()  # base -> null
                 cg.rot_two()    # null -> base
             cmn.load_helper(cg, 'validate_declarative')
@@ -127,7 +127,7 @@ class FirstPassEnamlDefCompiler(block.FirstPassBlockCompiler):
         # Build the compiler node
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
             cg.rot_two()
         should_store = cmn.should_store_locals(node)
@@ -273,7 +273,7 @@ class EnamlDefCompiler(cmn.CompilerBase):
         )
 
         # Prepare the code block for execution.
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cmn.fetch_helpers(cg)
         cmn.load_helper(cg, 'make_object')
@@ -285,7 +285,7 @@ class EnamlDefCompiler(cmn.CompilerBase):
         # Load and invoke the first pass code object.
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cg.load_const(first_code)
         cg.make_function()
@@ -299,7 +299,7 @@ class EnamlDefCompiler(cmn.CompilerBase):
         # Load and invoke the second pass code object.
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cg.load_const(second_code)
         cg.make_function()

--- a/enaml/core/template_compiler.py
+++ b/enaml/core/template_compiler.py
@@ -10,7 +10,7 @@ from atom.api import List, Typed
 from . import block_compiler as block
 from . import compiler_common as cmn
 from .enaml_ast import ConstExpr, Template
-from ..compat import PY311, PY313
+from ..compat import PY313
 
 
 def collect_local_names(node):
@@ -124,7 +124,7 @@ class FirstPassTemplateCompiler(block.FirstPassBlockCompiler):
         # Create the template compiler node and store in the node list.
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cmn.load_helper(cg, 'template_node')
         if PY313:
@@ -173,7 +173,7 @@ class FirstPassTemplateCompiler(block.FirstPassBlockCompiler):
                 cg.dup_top()
                 # Python 3.11 and 3.12 requires a NULL before a function that is not a method
                 # Python 3.13 one after
-                if not PY313 and PY311:
+                if not PY313:
                     cg.push_null()
                     cg.rot_two()
                 cmn.load_helper(cg, 'type_check_expr')
@@ -333,7 +333,7 @@ class TemplateCompiler(cmn.CompilerBase):
         cmn.fetch_helpers(cg)
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cmn.load_helper(cg, 'make_object')
         if PY313:
@@ -344,7 +344,7 @@ class TemplateCompiler(cmn.CompilerBase):
         # Load and invoke the first pass code object.
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cg.load_const(first_code)
         cg.make_function()
@@ -360,7 +360,7 @@ class TemplateCompiler(cmn.CompilerBase):
         # Load and invoke the second pass code object.
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
         cg.load_const(second_code)
         cg.make_function()
@@ -378,7 +378,7 @@ class TemplateCompiler(cmn.CompilerBase):
         cg.dup_top()
         # Python 3.11 and 3.12 requires a NULL before a function that is not a method
         # Python 3.13 one after
-        if not PY313 and PY311:
+        if not PY313:
             cg.push_null()
             cg.rot_two()
         cmn.load_helper(cg, 'add_template_scope')

--- a/tests/core/parser/test_parser.py
+++ b/tests/core/parser/test_parser.py
@@ -13,8 +13,6 @@ import pytest
 import traceback
 from textwrap import dedent
 
-from enaml.compat import PY311
-
 
 def validate_ast(py_node, enaml_node, dump_ast=False, offset=0):
     """Validate each node of an ast against another ast.


### PR DESCRIPTION
Due to the min version, PY311 is now constant `True` and can be removed.