### PR TITLE
Fix annotation fn's not runing in dynamicscope for #616

### DIFF
--- a/enaml/core/code_generator.py
+++ b/enaml/core/code_generator.py
@@ -297,8 +297,8 @@ class CodeGenerator(Atom):
             bc.Instr("LOAD_BUILD_CLASS"),  # TOS -> builtins.__build_class__
         )
 
-    def make_function(self, flags=0, name=None):
-        """Make a function from a code object on the TOS."""
+    def make_method(self, flags=0):
+        """Make a method from a code object on the TOS."""
         if PY313:
             if flags:
                 self.code_ops.extend(
@@ -315,6 +315,18 @@ class CodeGenerator(Atom):
             self.code_ops.append(  # TOS -> qual_name -> code -> defaults
                 bc.Instr("MAKE_FUNCTION", flags),  # TOS -> func
             )
+
+    def make_function(self, flags=0):
+        """Make a function from a code object on the TOS."""
+        if PY313:
+            # Python 3.13 requires a NULL after a function that is not a method
+            self.make_method(flags)
+            self.push_null()
+        else:
+            # Python 3.11 and 3.12 requires a NULL before a function that is not a method
+            self.push_null()  # code -> null
+            self.rot_two()   # null -> code
+            self.make_method(flags)
 
     def push_null(self):
         """Push NULL on the TOS."""

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -906,20 +906,25 @@ def _insert_decl_function(cg, funcdef):
     # Python 3.12 uses RETURN_CONST
     outer_ops = bc.Bytecode.from_code(code)[0:(-2 if not PY314 and PY312 else -3)]
 
-    # the stack now looks like the following:
+    # On 3.14 if the function has annotations it looks like
+    #   ...
+    #   LOAD_CONST      (<code object __annotate__>)
+    #   MAKE_FUNCTION   (flag)              // TOS
+    #   LOAD_CONST      (<code object>)
+    #   MAKE_FUNCTION   (flag)              // TOS
+
+    # Otherwise the stack now looks like the following:
     #   ...
     #   LOAD_CONST      (<code object>)
-    #   MAKE_FUCTION    (flag)              // TOS
+    #   MAKE_FUNCTION   (flag)              // TOS
 
     # Look for the MAKE_FUNCTION instruction
     # 3.13 make the exact position variable due to the possible existence of
     # a SET_FUNCTION_ATTRIBUTE
+    code_index = 0
     for index, i in enumerate(outer_ops):
         if i.name == "MAKE_FUNCTION":
-            break
-    else:
-        index = 0
-    code_index = index - 1
+            code_index = index - 1
     assert code_index >= 0
 
     # extract the inner code object which represents the actual

--- a/enaml/core/compiler_common.py
+++ b/enaml/core/compiler_common.py
@@ -553,7 +553,7 @@ def gen_child_def_node(cg: CodeGenerator, node: ChildDef, local_names: set[str])
 
         class_code = class_cg.to_code()
         cg.load_const(class_code)
-        cg.make_function()
+        cg.make_method()
 
         cg.rot_two()                            # builtins.__build_class_ -> class_func -> base
         cg.load_const(node.typename)

--- a/enaml/core/enaml_compiler.py
+++ b/enaml/core/enaml_compiler.py
@@ -215,13 +215,9 @@ class EnamlCompiler(cmn.CompilerBase):
     def visit_EnamlDef(self, node):
         # Invoke the enamldef code and store result in the namespace.
         cg = self.code_generator
-        if not PY313:
-            cg.push_null()
         code = EnamlDefCompiler.compile(node, cg.filename)
         cg.load_const(code)
         cg.make_function()
-        if PY313:
-            cg.push_null()
         cg.call_function()
         cg.store_global(node.typename)
 
@@ -271,7 +267,7 @@ class EnamlCompiler(cmn.CompilerBase):
             # Generate the template code and function
             code = TemplateCompiler.compile(node, cg.filename)
             cg.load_const(code)                                      # tuple -> code
-            cg.make_function(0x01)                                   # tuple -> func
+            cg.make_method(0x01)                                     # tuple -> func
 
             # Load and call the helper which will build the template
             cmn.load_helper(cg, 'make_template', from_globals=True)  # tuple -> func -> helper

--- a/enaml/core/enamldef_compiler.py
+++ b/enaml/core/enamldef_compiler.py
@@ -283,28 +283,16 @@ class EnamlDefCompiler(cmn.CompilerBase):
         cg.store_fast(cmn.SCOPE_KEY)
 
         # Load and invoke the first pass code object.
-        # Python 3.11 and 3.12 requires a NULL before a function that is not a method
-        # Python 3.13 one after
-        if not PY313:
-            cg.push_null()
         cg.load_const(first_code)
         cg.make_function()
-        if PY313:
-            cg.push_null()
         for arg in first_args:
             cg.load_fast(arg)
         cg.call_function(len(first_args))
         cg.store_fast(cmn.NODE_LIST)
 
         # Load and invoke the second pass code object.
-        # Python 3.11 and 3.12 requires a NULL before a function that is not a method
-        # Python 3.13 one after
-        if not PY313:
-            cg.push_null()
         cg.load_const(second_code)
         cg.make_function()
-        if PY313:
-            cg.push_null()
         for arg in second_args:
             cg.load_fast(arg)
         cg.call_function(len(second_args))

--- a/enaml/core/template_compiler.py
+++ b/enaml/core/template_compiler.py
@@ -342,14 +342,8 @@ class TemplateCompiler(cmn.CompilerBase):
         cg.store_fast(cmn.SCOPE_KEY)
 
         # Load and invoke the first pass code object.
-        # Python 3.11 and 3.12 requires a NULL before a function that is not a method
-        # Python 3.13 one after
-        if not PY313:
-            cg.push_null()
         cg.load_const(first_code)
         cg.make_function()
-        if PY313:
-            cg.push_null()
         for arg in first_args:
             cg.load_fast(arg)
         cg.call_function(len(first_args))
@@ -358,14 +352,8 @@ class TemplateCompiler(cmn.CompilerBase):
         cg.store_fast(cmn.T_CONSTS)
 
         # Load and invoke the second pass code object.
-        # Python 3.11 and 3.12 requires a NULL before a function that is not a method
-        # Python 3.13 one after
-        if not PY313:
-            cg.push_null()
         cg.load_const(second_code)
         cg.make_function()
-        if PY313:
-            cg.push_null()
         for arg in second_args:
             cg.load_fast(arg)
         cg.call_function(len(second_args))

--- a/tests/core/test_declarative_function.py
+++ b/tests/core/test_declarative_function.py
@@ -63,7 +63,7 @@ def test_declarative_function_get_and_call():
             assert main is self
             return main
 
-        func call2():
+        func call2() -> Window:
             return main
 
     """)


### PR DESCRIPTION
This builds on #618. 

The commit https://github.com/nucleic/enaml/commit/7478234c799a6ab3aaa631cafa66f564496afb2e is not necessary but cleans up the code slightly (I can move it to a separate PR).

For context, I added a few statements to print the function and outer_ops in [insert_decl_function](https://github.com/frmdstryr/enaml/blob/main/enaml/core/compiler_common.py#L924) and ran the code in #616 on 3.14.The output was:
```py
FunctionDef(name='a', args=arguments(posonlyargs=[], args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Expr(value=Call(func=Name(...), args=[Constant(...)], keywords=[])), Expr(value=Call(func=Name(...), args=[Name(...)], keywords=[]))], decorator_list=[], returns=None, type_comment=None, type_params=[])
Ops:
<RESUME arg=0 location=InstrLocation(lineno=0, end_lineno=1, col_offset=0, end_col_offset=0)>
<LOAD_CONST arg=<code object a at 0x7191566f7880, file "tests/issue.enaml", line 6> location=InstrLocation(lineno=6, end_lineno=8, col_offset=4, end_col_offset=19)>
<MAKE_FUNCTION location=InstrLocation(lineno=6, end_lineno=8, col_offset=4, end_col_offset=19)>

FunctionDef(name='b', args=arguments(posonlyargs=[], args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]), body=[Expr(value=Call(func=Name(...), args=[Constant(...)], keywords=[])), Expr(value=Call(func=Name(...), args=[Name(...)], keywords=[]))], decorator_list=[], returns=Constant(value=None, kind=None), type_comment=None, type_params=[])
Ops:
<RESUME arg=0 location=InstrLocation(lineno=0, end_lineno=1, col_offset=0, end_col_offset=0)>
<LOAD_CONST arg=<code object __annotate__ at 0x719156670210, file "tests/issue.enaml", line 10> location=InstrLocation(lineno=10, end_lineno=12, col_offset=4, end_col_offset=19)>
<MAKE_FUNCTION location=InstrLocation(lineno=10, end_lineno=12, col_offset=4, end_col_offset=19)>
<LOAD_CONST arg=<code object b at 0x7191566f7880, file "tests/issue.enaml", line 10> location=InstrLocation(lineno=10, end_lineno=12, col_offset=4, end_col_offset=19)>
<MAKE_FUNCTION location=InstrLocation(lineno=10, end_lineno=12, col_offset=4, end_col_offset=19)>
<SET_FUNCTION_ATTRIBUTE arg=16 location=InstrLocation(lineno=10, end_lineno=12, col_offset=4, end_col_offset=19)>
```

So it looks like python adds a separate function for annotations and it was selecting the code from the first function.