### PR TITLE
Patch d member after adding to class

### DIFF
--- a/enaml/core/compiler_helpers.py
+++ b/enaml/core/compiler_helpers.py
@@ -154,8 +154,8 @@ def add_storage(node, name, store_type, kind):
     else:
         raise RuntimeError("invalid kind '%s'" % kind)
 
-    patch_d_member(new)
     add_member(klass, name, new)
+    patch_d_member(new)
 
 
 def declarative_node(klass, identifier, scope_key, store_locals):


### PR DESCRIPTION
I've been working on a port of atom more optimized for enaml-web. Due to how observation works in my port it requires that members be attached to a class before observers can be added. This is only change to enaml needed for my port to work. This makes it consistent with the other use of patch_d_member in DeclarativeMeta.